### PR TITLE
build-docker creates a scratch Docker image

### DIFF
--- a/Dockerfile.build-exec
+++ b/Dockerfile.build-exec
@@ -1,0 +1,9 @@
+FROM golang:alpine
+ENV CGO_ENABLED=0
+WORKDIR /go/src/github.com/coreos/container-linux-config-transpiler
+COPY . .
+RUN apk update \
+    && apk add bash \
+    && ./build \
+    && cp bin/ct /usr/bin/
+ENTRYPOINT ["/usr/bin/ct"]

--- a/Dockerfile.build-image
+++ b/Dockerfile.build-image
@@ -1,0 +1,3 @@
+FROM scratch
+COPY bin/ct /ct
+ENTRYPOINT ["/ct"]

--- a/build-docker
+++ b/build-docker
@@ -1,0 +1,4 @@
+#!/bin/sh
+SHA=`git rev-parse HEAD`
+docker build -t $SHA -f Dockerfile.build-exec . &&
+    docker run --rm --entrypoint tar $SHA -c bin/ct Dockerfile.build-image | docker build -f Dockerfile.build-image --tag coreos/ct -


### PR DESCRIPTION
Usage:
docker run -i --rm coreos/ct <ignition.yaml >ignition.json