### PR TITLE
internal/main: in-file and out-file flags were broken

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -64,13 +64,23 @@ func main() {
 	if flags.inFile == "" {
 		inFile = os.Stdin
 	} else {
-		os.Open(flags.inFile)
+		var err error
+		inFile, err = os.Open(flags.inFile)
+		if err != nil {
+			stderr("Failed to open: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	if flags.outFile == "" {
 		outFile = os.Stdout
 	} else {
-		os.Create(flags.outFile)
+		var err error
+		outFile, err = os.Create(flags.outFile)
+		if err != nil {
+			stderr("Failed to create: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	dataIn, err := ioutil.ReadAll(inFile)


### PR DESCRIPTION
The in-file and out-file logic failed to assign the opened/created file
pointers to the local variables, resulting in these flags being broken.
This commit fixes that.