### PR TITLE
config/{etcd,flannel}: pass options via command line instead of env vars

### DIFF
--- a/config/types/etcd.go
+++ b/config/types/etcd.go
@@ -122,146 +122,146 @@ func init() {
 
 // etcdContents creates the string containing the systemd drop in for etcd-member
 func etcdContents(etcd Etcd) string {
-	vars := getEnvVars(etcd.Options)
-	// Add the tag
-	vars = append(vars, fmt.Sprintf("ETCD_IMAGE_TAG=v%s", etcd.Version))
-	return serviceContentsFromEnvVars(vars)
+	args := getCliArgs(etcd.Options)
+	vars := []string{fmt.Sprintf("ETCD_IMAGE_TAG=v%s", etcd.Version)}
+
+	return assembleUnit("/usr/lib/coreos/etcd-wrapper $ETCD_OPTS", args, vars)
 }
 
 type Etcd3_0 struct {
-	Name                     string `yaml:"name"                        env:"ETCD_NAME"`
-	DataDir                  string `yaml:"data_dir"                    env:"ETCD_DATA_DIR"`
-	WalDir                   string `yaml:"wal_dir"                     env:"ETCD_WAL_DIR"`
-	SnapshotCount            int    `yaml:"snapshot_count"              env:"ETCD_SNAPSHOT_COUNT"`
-	HeartbeatInterval        int    `yaml:"heartbeat_interval"          env:"ETCD_HEARTBEAT_INTERVAL"`
-	ElectionTimeout          int    `yaml:"election_timeout"            env:"ETCD_ELECTION_TIMEOUT"`
-	ListenPeerUrls           string `yaml:"listen_peer_urls"            env:"ETCD_LISTEN_PEER_URLS"`
-	ListenClientUrls         string `yaml:"listen_client_urls"          env:"ETCD_LISTEN_CLIENT_URLS"`
-	MaxSnapshots             int    `yaml:"max_snapshots"               env:"ETCD_MAX_SNAPSHOTS"`
-	MaxWals                  int    `yaml:"max_wals"                    env:"ETCD_MAX_WALS"`
-	Cors                     string `yaml:"cors"                        env:"ETCD_CORS"`
-	InitialAdvertisePeerUrls string `yaml:"initial_advertise_peer_urls" env:"ETCD_INITIAL_ADVERTISE_PEER_URLS"`
-	InitialCluster           string `yaml:"initial_cluster"             env:"ETCD_INITIAL_CLUSTER"`
-	InitialClusterState      string `yaml:"initial_cluster_state"       env:"ETCD_INITIAL_CLUSTER_STATE"`
-	InitialClusterToken      string `yaml:"initial_cluster_token"       env:"ETCD_INITIAL_CLUSTER_TOKEN"`
-	AdvertiseClientUrls      string `yaml:"advertise_client_urls"       env:"ETCD_ADVERTISE_CLIENT_URLS"`
-	Discovery                string `yaml:"discovery"                   env:"ETCD_DISCOVERY"`
-	DiscoverySrv             string `yaml:"discovery_srv"               env:"ETCD_DISCOVERY_SRV"`
-	DiscoveryFallback        string `yaml:"discovery_fallback"          env:"ETCD_DISCOVERY_FALLBACK"`
-	DiscoveryProxy           string `yaml:"discovery_proxy"             env:"ETCD_DISCOVERY_PROXY"`
-	StrictReconfigCheck      bool   `yaml:"strict_reconfig_check"       env:"ETCD_STRICT_RECONFIG_CHECK"`
-	AutoCompactionRetention  int    `yaml:"auto_compaction_retention"   env:"ETCD_AUTO_COMPACTION_RETENTION"`
-	Proxy                    string `yaml:"proxy"                       env:"ETCD_PROXY"`
-	ProxyFailureWait         int    `yaml:"proxy_failure_wait"          env:"ETCD_PROXY_FAILURE_WAIT"`
-	ProxyRefreshInterval     int    `yaml:"proxy_refresh_interval"      env:"ETCD_PROXY_REFRESH_INTERVAL"`
-	ProxyDialTimeout         int    `yaml:"proxy_dial_timeout"          env:"ETCD_PROXY_DIAL_TIMEOUT"`
-	ProxyWriteTimeout        int    `yaml:"proxy_write_timeout"         env:"ETCD_PROXY_WRITE_TIMEOUT"`
-	ProxyReadTimeout         int    `yaml:"proxy_read_timeout"          env:"ETCD_PROXY_READ_TIMEOUT"`
-	CaFile                   string `yaml:"ca_file"                     env:"ETCD_CA_FILE"                     deprecated:"ca_file obsoleted by trusted_ca_file and client_cert_auth"`
-	CertFile                 string `yaml:"cert_file"                   env:"ETCD_CERT_FILE"`
-	KeyFile                  string `yaml:"key_file"                    env:"ETCD_KEY_FILE"`
-	ClientCertAuth           bool   `yaml:"client_cert_auth"            env:"ETCD_CLIENT_CERT_AUTH"`
-	TrustedCaFile            string `yaml:"trusted_ca_file"             env:"ETCD_TRUSTED_CA_FILE"`
-	AutoTls                  bool   `yaml:"auto_tls"                    env:"ETCD_AUTO_TLS"`
-	PeerCaFile               string `yaml:"peer_ca_file"                env:"ETCD_PEER_CA_FILE"                deprecated:"peer_ca_file obsoleted peer_trusted_ca_file and peer_client_cert_auth"`
-	PeerCertFile             string `yaml:"peer_cert_file"              env:"ETCD_PEER_CERT_FILE"`
-	PeerKeyFile              string `yaml:"peer_key_file"               env:"ETCD_PEER_KEY_FILE"`
-	PeerClientCertAuth       bool   `yaml:"peer_client_cert_auth"       env:"ETCD_PEER_CLIENT_CERT_AUTH"`
-	PeerTrustedCaFile        string `yaml:"peer_trusted_ca_file"        env:"ETCD_PEER_TRUSTED_CA_FILE"`
-	PeerAutoTls              bool   `yaml:"peer_auto_tls"               env:"ETCD_PEER_AUTO_TLS"`
-	Debug                    bool   `yaml:"debug"                       env:"ETCD_DEBUG"`
-	LogPackageLevels         string `yaml:"log_package_levels"          env:"ETCD_LOG_PACKAGE_LEVELS"`
-	ForceNewCluster          bool   `yaml:"force_new_cluster"           env:"ETCD_FORCE_NEW_CLUSTER"`
+	Name                     string `yaml:"name"                        cli:"name"`
+	DataDir                  string `yaml:"data_dir"                    cli:"data-dir"`
+	WalDir                   string `yaml:"wal_dir"                     cli:"wal-dir"`
+	SnapshotCount            int    `yaml:"snapshot_count"              cli:"snapshot-count"`
+	HeartbeatInterval        int    `yaml:"heartbeat_interval"          cli:"heartbeat-interval"`
+	ElectionTimeout          int    `yaml:"election_timeout"            cli:"election-timeout"`
+	ListenPeerUrls           string `yaml:"listen_peer_urls"            cli:"listen-peer-urls"`
+	ListenClientUrls         string `yaml:"listen_client_urls"          cli:"listen-client-urls"`
+	MaxSnapshots             int    `yaml:"max_snapshots"               cli:"max-snapshots"`
+	MaxWals                  int    `yaml:"max_wals"                    cli:"max-wals"`
+	Cors                     string `yaml:"cors"                        cli:"cors"`
+	InitialAdvertisePeerUrls string `yaml:"initial_advertise_peer_urls" cli:"initial-advertise-peer-urls"`
+	InitialCluster           string `yaml:"initial_cluster"             cli:"initial-cluster"`
+	InitialClusterState      string `yaml:"initial_cluster_state"       cli:"initial-cluster-state"`
+	InitialClusterToken      string `yaml:"initial_cluster_token"       cli:"initial-cluster-token"`
+	AdvertiseClientUrls      string `yaml:"advertise_client_urls"       cli:"advertise-client-urls"`
+	Discovery                string `yaml:"discovery"                   cli:"discovery"`
+	DiscoverySrv             string `yaml:"discovery_srv"               cli:"discovery-srv"`
+	DiscoveryFallback        string `yaml:"discovery_fallback"          cli:"discovery-fallback"`
+	DiscoveryProxy           string `yaml:"discovery_proxy"             cli:"discovery-proxy"`
+	StrictReconfigCheck      bool   `yaml:"strict_reconfig_check"       cli:"strict-reconfig-check"`
+	AutoCompactionRetention  int    `yaml:"auto_compaction_retention"   cli:"auto-compaction-retention"`
+	Proxy                    string `yaml:"proxy"                       cli:"proxy"`
+	ProxyFailureWait         int    `yaml:"proxy_failure_wait"          cli:"proxy-failure-wait"`
+	ProxyRefreshInterval     int    `yaml:"proxy_refresh_interval"      cli:"proxy-refresh-interval"`
+	ProxyDialTimeout         int    `yaml:"proxy_dial_timeout"          cli:"proxy-dial-timeout"`
+	ProxyWriteTimeout        int    `yaml:"proxy_write_timeout"         cli:"proxy-write-timeout"`
+	ProxyReadTimeout         int    `yaml:"proxy_read_timeout"          cli:"proxy-read-timeout"`
+	CaFile                   string `yaml:"ca_file"                     cli:"ca-file"                     deprecated:"ca_file obsoleted by trusted_ca_file and client_cert_auth"`
+	CertFile                 string `yaml:"cert_file"                   cli:"cert-file"`
+	KeyFile                  string `yaml:"key_file"                    cli:"key-file"`
+	ClientCertAuth           bool   `yaml:"client_cert_auth"            cli:"client-cert-auth"`
+	TrustedCaFile            string `yaml:"trusted_ca_file"             cli:"trusted-ca-file"`
+	AutoTls                  bool   `yaml:"auto_tls"                    cli:"auto-tls"`
+	PeerCaFile               string `yaml:"peer_ca_file"                cli:"peer-ca-file"                deprecated:"peer_ca_file obsoleted peer_trusted_ca_file and peer_client_cert_auth"`
+	PeerCertFile             string `yaml:"peer_cert_file"              cli:"peer-cert-file"`
+	PeerKeyFile              string `yaml:"peer_key_file"               cli:"peer-key-file"`
+	PeerClientCertAuth       bool   `yaml:"peer_client_cert_auth"       cli:"peer-client-cert-auth"`
+	PeerTrustedCaFile        string `yaml:"peer_trusted_ca_file"        cli:"peer-trusted-ca-file"`
+	PeerAutoTls              bool   `yaml:"peer_auto_tls"               cli:"peer-auto-tls"`
+	Debug                    bool   `yaml:"debug"                       cli:"debug"`
+	LogPackageLevels         string `yaml:"log_package_levels"          cli:"log-package-levels"`
+	ForceNewCluster          bool   `yaml:"force_new_cluster"           cli:"force-new-cluster"`
 }
 
 type Etcd3_1 struct {
-	Name                     string `yaml:"name"                        env:"ETCD_NAME"`
-	DataDir                  string `yaml:"data_dir"                    env:"ETCD_DATA_DIR"`
-	WalDir                   string `yaml:"wal_dir"                     env:"ETCD_WAL_DIR"`
-	SnapshotCount            int    `yaml:"snapshot_count"              env:"ETCD_SNAPSHOT_COUNT"`
-	HeartbeatInterval        int    `yaml:"heartbeat_interval"          env:"ETCD_HEARTBEAT_INTERVAL"`
-	ElectionTimeout          int    `yaml:"election_timeout"            env:"ETCD_ELECTION_TIMEOUT"`
-	ListenPeerUrls           string `yaml:"listen_peer_urls"            env:"ETCD_LISTEN_PEER_URLS"`
-	ListenClientUrls         string `yaml:"listen_client_urls"          env:"ETCD_LISTEN_CLIENT_URLS"`
-	MaxSnapshots             int    `yaml:"max_snapshots"               env:"ETCD_MAX_SNAPSHOTS"`
-	MaxWals                  int    `yaml:"max_wals"                    env:"ETCD_MAX_WALS"`
-	Cors                     string `yaml:"cors"                        env:"ETCD_CORS"`
-	InitialAdvertisePeerUrls string `yaml:"initial_advertise_peer_urls" env:"ETCD_INITIAL_ADVERTISE_PEER_URLS"`
-	InitialCluster           string `yaml:"initial_cluster"             env:"ETCD_INITIAL_CLUSTER"`
-	InitialClusterState      string `yaml:"initial_cluster_state"       env:"ETCD_INITIAL_CLUSTER_STATE"`
-	InitialClusterToken      string `yaml:"initial_cluster_token"       env:"ETCD_INITIAL_CLUSTER_TOKEN"`
-	AdvertiseClientUrls      string `yaml:"advertise_client_urls"       env:"ETCD_ADVERTISE_CLIENT_URLS"`
-	Discovery                string `yaml:"discovery"                   env:"ETCD_DISCOVERY"`
-	DiscoverySrv             string `yaml:"discovery_srv"               env:"ETCD_DISCOVERY_SRV"`
-	DiscoveryFallback        string `yaml:"discovery_fallback"          env:"ETCD_DISCOVERY_FALLBACK"`
-	DiscoveryProxy           string `yaml:"discovery_proxy"             env:"ETCD_DISCOVERY_PROXY"`
-	StrictReconfigCheck      bool   `yaml:"strict_reconfig_check"       env:"ETCD_STRICT_RECONFIG_CHECK"`
-	AutoCompactionRetention  int    `yaml:"auto_compaction_retention"   env:"ETCD_AUTO_COMPACTION_RETENTION"`
-	Proxy                    string `yaml:"proxy"                       env:"ETCD_PROXY"`
-	ProxyFailureWait         int    `yaml:"proxy_failure_wait"          env:"ETCD_PROXY_FAILURE_WAIT"`
-	ProxyRefreshInterval     int    `yaml:"proxy_refresh_interval"      env:"ETCD_PROXY_REFRESH_INTERVAL"`
-	ProxyDialTimeout         int    `yaml:"proxy_dial_timeout"          env:"ETCD_PROXY_DIAL_TIMEOUT"`
-	ProxyWriteTimeout        int    `yaml:"proxy_write_timeout"         env:"ETCD_PROXY_WRITE_TIMEOUT"`
-	ProxyReadTimeout         int    `yaml:"proxy_read_timeout"          env:"ETCD_PROXY_READ_TIMEOUT"`
-	CaFile                   string `yaml:"ca_file"                     env:"ETCD_CA_FILE"                     deprecated:"ca_file obsoleted by trusted_ca_file and client_cert_auth"`
-	CertFile                 string `yaml:"cert_file"                   env:"ETCD_CERT_FILE"`
-	KeyFile                  string `yaml:"key_file"                    env:"ETCD_KEY_FILE"`
-	ClientCertAuth           bool   `yaml:"client_cert_auth"            env:"ETCD_CLIENT_CERT_AUTH"`
-	TrustedCaFile            string `yaml:"trusted_ca_file"             env:"ETCD_TRUSTED_CA_FILE"`
-	AutoTls                  bool   `yaml:"auto_tls"                    env:"ETCD_AUTO_TLS"`
-	PeerCaFile               string `yaml:"peer_ca_file"                env:"ETCD_PEER_CA_FILE"                deprecated:"peer_ca_file obsoleted peer_trusted_ca_file and peer_client_cert_auth"`
-	PeerCertFile             string `yaml:"peer_cert_file"              env:"ETCD_PEER_CERT_FILE"`
-	PeerKeyFile              string `yaml:"peer_key_file"               env:"ETCD_PEER_KEY_FILE"`
-	PeerClientCertAuth       bool   `yaml:"peer_client_cert_auth"       env:"ETCD_PEER_CLIENT_CERT_AUTH"`
-	PeerTrustedCaFile        string `yaml:"peer_trusted_ca_file"        env:"ETCD_PEER_TRUSTED_CA_FILE"`
-	PeerAutoTls              bool   `yaml:"peer_auto_tls"               env:"ETCD_PEER_AUTO_TLS"`
-	Debug                    bool   `yaml:"debug"                       env:"ETCD_DEBUG"`
-	LogPackageLevels         string `yaml:"log_package_levels"          env:"ETCD_LOG_PACKAGE_LEVELS"`
-	ForceNewCluster          bool   `yaml:"force_new_cluster"           env:"ETCD_FORCE_NEW_CLUSTER"`
-	Metrics                  string `yaml:"metrics"                     env:"ETCD_METRICS"`
-	LogOutput                string `yaml:"log_output"                  env:"ETCD_LOG_OUTPUT"`
+	Name                     string `yaml:"name"                        cli:"name"`
+	DataDir                  string `yaml:"data_dir"                    cli:"data-dir"`
+	WalDir                   string `yaml:"wal_dir"                     cli:"wal-dir"`
+	SnapshotCount            int    `yaml:"snapshot_count"              cli:"snapshot-count"`
+	HeartbeatInterval        int    `yaml:"heartbeat_interval"          cli:"heartbeat-interval"`
+	ElectionTimeout          int    `yaml:"election_timeout"            cli:"election-timeout"`
+	ListenPeerUrls           string `yaml:"listen_peer_urls"            cli:"listen-peer-urls"`
+	ListenClientUrls         string `yaml:"listen_client_urls"          cli:"listen-client-urls"`
+	MaxSnapshots             int    `yaml:"max_snapshots"               cli:"max-snapshots"`
+	MaxWals                  int    `yaml:"max_wals"                    cli:"max-wals"`
+	Cors                     string `yaml:"cors"                        cli:"cors"`
+	InitialAdvertisePeerUrls string `yaml:"initial_advertise_peer_urls" cli:"initial-advertise-peer-urls"`
+	InitialCluster           string `yaml:"initial_cluster"             cli:"initial-cluster"`
+	InitialClusterState      string `yaml:"initial_cluster_state"       cli:"initial-cluster-state"`
+	InitialClusterToken      string `yaml:"initial_cluster_token"       cli:"initial-cluster-token"`
+	AdvertiseClientUrls      string `yaml:"advertise_client_urls"       cli:"advertise-client-urls"`
+	Discovery                string `yaml:"discovery"                   cli:"discovery"`
+	DiscoverySrv             string `yaml:"discovery_srv"               cli:"discovery-srv"`
+	DiscoveryFallback        string `yaml:"discovery_fallback"          cli:"discovery-fallback"`
+	DiscoveryProxy           string `yaml:"discovery_proxy"             cli:"discovery-proxy"`
+	StrictReconfigCheck      bool   `yaml:"strict_reconfig_check"       cli:"strict-reconfig-check"`
+	AutoCompactionRetention  int    `yaml:"auto_compaction_retention"   cli:"auto-compaction-retention"`
+	Proxy                    string `yaml:"proxy"                       cli:"proxy"`
+	ProxyFailureWait         int    `yaml:"proxy_failure_wait"          cli:"proxy-failure-wait"`
+	ProxyRefreshInterval     int    `yaml:"proxy_refresh_interval"      cli:"proxy-refresh-interval"`
+	ProxyDialTimeout         int    `yaml:"proxy_dial_timeout"          cli:"proxy-dial-timeout"`
+	ProxyWriteTimeout        int    `yaml:"proxy_write_timeout"         cli:"proxy-write-timeout"`
+	ProxyReadTimeout         int    `yaml:"proxy_read_timeout"          cli:"proxy-read-timeout"`
+	CaFile                   string `yaml:"ca_file"                     cli:"ca-file"                     deprecated:"ca_file obsoleted by trusted_ca_file and client_cert_auth"`
+	CertFile                 string `yaml:"cert_file"                   cli:"cert-file"`
+	KeyFile                  string `yaml:"key_file"                    cli:"key-file"`
+	ClientCertAuth           bool   `yaml:"client_cert_auth"            cli:"client-cert-auth"`
+	TrustedCaFile            string `yaml:"trusted_ca_file"             cli:"trusted-ca-file"`
+	AutoTls                  bool   `yaml:"auto_tls"                    cli:"auto-tls"`
+	PeerCaFile               string `yaml:"peer_ca_file"                cli:"peer-ca-file"                deprecated:"peer_ca_file obsoleted peer_trusted_ca_file and peer_client_cert_auth"`
+	PeerCertFile             string `yaml:"peer_cert_file"              cli:"peer-cert-file"`
+	PeerKeyFile              string `yaml:"peer_key_file"               cli:"peer-key-file"`
+	PeerClientCertAuth       bool   `yaml:"peer_client_cert_auth"       cli:"peer-client-cert-auth"`
+	PeerTrustedCaFile        string `yaml:"peer_trusted_ca_file"        cli:"peer-trusted-ca-file"`
+	PeerAutoTls              bool   `yaml:"peer_auto_tls"               cli:"peer-auto-tls"`
+	Debug                    bool   `yaml:"debug"                       cli:"debug"`
+	LogPackageLevels         string `yaml:"log_package_levels"          cli:"log-package-levels"`
+	ForceNewCluster          bool   `yaml:"force_new_cluster"           cli:"force-new-cluster"`
+	Metrics                  string `yaml:"metrics"                     cli:"metrics"`
+	LogOutput                string `yaml:"log_output"                  cli:"log-output"`
 }
 
 type Etcd2 struct {
-	AdvertiseClientURLs      string `yaml:"advertise_client_urls"         env:"ETCD_ADVERTISE_CLIENT_URLS"`
-	CAFile                   string `yaml:"ca_file"                       env:"ETCD_CA_FILE"                     deprecated:"ca_file obsoleted by trusted_ca_file and client_cert_auth"`
-	CertFile                 string `yaml:"cert_file"                     env:"ETCD_CERT_FILE"`
-	ClientCertAuth           bool   `yaml:"client_cert_auth"              env:"ETCD_CLIENT_CERT_AUTH"`
-	CorsOrigins              string `yaml:"cors"                          env:"ETCD_CORS"`
-	DataDir                  string `yaml:"data_dir"                      env:"ETCD_DATA_DIR"`
-	Debug                    bool   `yaml:"debug"                         env:"ETCD_DEBUG"`
-	Discovery                string `yaml:"discovery"                     env:"ETCD_DISCOVERY"`
-	DiscoveryFallback        string `yaml:"discovery_fallback"            env:"ETCD_DISCOVERY_FALLBACK"`
-	DiscoverySRV             string `yaml:"discovery_srv"                 env:"ETCD_DISCOVERY_SRV"`
-	DiscoveryProxy           string `yaml:"discovery_proxy"               env:"ETCD_DISCOVERY_PROXY"`
-	ElectionTimeout          int    `yaml:"election_timeout"              env:"ETCD_ELECTION_TIMEOUT"`
-	EnablePprof              bool   `yaml:"enable_pprof"                  env:"ETCD_ENABLE_PPROF"`
-	ForceNewCluster          bool   `yaml:"force_new_cluster"             env:"ETCD_FORCE_NEW_CLUSTER"`
-	HeartbeatInterval        int    `yaml:"heartbeat_interval"            env:"ETCD_HEARTBEAT_INTERVAL"`
-	InitialAdvertisePeerURLs string `yaml:"initial_advertise_peer_urls"   env:"ETCD_INITIAL_ADVERTISE_PEER_URLS"`
-	InitialCluster           string `yaml:"initial_cluster"               env:"ETCD_INITIAL_CLUSTER"`
-	InitialClusterState      string `yaml:"initial_cluster_state"         env:"ETCD_INITIAL_CLUSTER_STATE"`
-	InitialClusterToken      string `yaml:"initial_cluster_token"         env:"ETCD_INITIAL_CLUSTER_TOKEN"`
-	KeyFile                  string `yaml:"key_file"                      env:"ETCD_KEY_FILE"`
-	ListenClientURLs         string `yaml:"listen_client_urls"            env:"ETCD_LISTEN_CLIENT_URLS"`
-	ListenPeerURLs           string `yaml:"listen_peer_urls"              env:"ETCD_LISTEN_PEER_URLS"`
-	LogPackageLevels         string `yaml:"log_package_levels"            env:"ETCD_LOG_PACKAGE_LEVELS"`
-	MaxSnapshots             int    `yaml:"max_snapshots"                 env:"ETCD_MAX_SNAPSHOTS"`
-	MaxWALs                  int    `yaml:"max_wals"                      env:"ETCD_MAX_WALS"`
-	Name                     string `yaml:"name"                          env:"ETCD_NAME"`
-	PeerCAFile               string `yaml:"peer_ca_file"                  env:"ETCD_PEER_CA_FILE"                deprecated:"peer_ca_file obsoleted peer_trusted_ca_file and peer_client_cert_auth"`
-	PeerCertFile             string `yaml:"peer_cert_file"                env:"ETCD_PEER_CERT_FILE"`
-	PeerKeyFile              string `yaml:"peer_key_file"                 env:"ETCD_PEER_KEY_FILE"`
-	PeerClientCertAuth       bool   `yaml:"peer_client_cert_auth"         env:"ETCD_PEER_CLIENT_CERT_AUTH"`
-	PeerTrustedCAFile        string `yaml:"peer_trusted_ca_file"          env:"ETCD_PEER_TRUSTED_CA_FILE"`
-	Proxy                    string `yaml:"proxy"                         env:"ETCD_PROXY"                       valid:"^(on|off|readonly)$"`
-	ProxyDialTimeout         int    `yaml:"proxy_dial_timeout"            env:"ETCD_PROXY_DIAL_TIMEOUT"`
-	ProxyFailureWait         int    `yaml:"proxy_failure_wait"            env:"ETCD_PROXY_FAILURE_WAIT"`
-	ProxyReadTimeout         int    `yaml:"proxy_read_timeout"            env:"ETCD_PROXY_READ_TIMEOUT"`
-	ProxyRefreshInterval     int    `yaml:"proxy_refresh_interval"        env:"ETCD_PROXY_REFRESH_INTERVAL"`
-	ProxyWriteTimeout        int    `yaml:"proxy_write_timeout"           env:"ETCD_PROXY_WRITE_TIMEOUT"`
-	SnapshotCount            int    `yaml:"snapshot_count"                env:"ETCD_SNAPSHOT_COUNT"`
-	StrictReconfigCheck      bool   `yaml:"strict_reconfig_check"         env:"ETCD_STRICT_RECONFIG_CHECK"`
-	TrustedCAFile            string `yaml:"trusted_ca_file"               env:"ETCD_TRUSTED_CA_FILE"`
-	WalDir                   string `yaml:"wal_dir"                       env:"ETCD_WAL_DIR"`
+	AdvertiseClientURLs      string `yaml:"advertise_client_urls"         cli:"advertise-client-urls"`
+	CAFile                   string `yaml:"ca_file"                       cli:"ca-file"                     deprecated:"ca_file obsoleted by trusted_ca_file and client_cert_auth"`
+	CertFile                 string `yaml:"cert_file"                     cli:"cert-file"`
+	ClientCertAuth           bool   `yaml:"client_cert_auth"              cli:"client-cert-auth"`
+	CorsOrigins              string `yaml:"cors"                          cli:"cors"`
+	DataDir                  string `yaml:"data_dir"                      cli:"data-dir"`
+	Debug                    bool   `yaml:"debug"                         cli:"debug"`
+	Discovery                string `yaml:"discovery"                     cli:"discovery"`
+	DiscoveryFallback        string `yaml:"discovery_fallback"            cli:"discovery-fallback"`
+	DiscoverySRV             string `yaml:"discovery_srv"                 cli:"discovery-srv"`
+	DiscoveryProxy           string `yaml:"discovery_proxy"               cli:"discovery-proxy"`
+	ElectionTimeout          int    `yaml:"election_timeout"              cli:"election-timeout"`
+	EnablePprof              bool   `yaml:"enable_pprof"                  cli:"enable-pprof"`
+	ForceNewCluster          bool   `yaml:"force_new_cluster"             cli:"force-new-cluster"`
+	HeartbeatInterval        int    `yaml:"heartbeat_interval"            cli:"heartbeat-interval"`
+	InitialAdvertisePeerURLs string `yaml:"initial_advertise_peer_urls"   cli:"initial-advertise-peer-urls"`
+	InitialCluster           string `yaml:"initial_cluster"               cli:"initial-cluster"`
+	InitialClusterState      string `yaml:"initial_cluster_state"         cli:"initial-cluster-state"`
+	InitialClusterToken      string `yaml:"initial_cluster_token"         cli:"initial-cluster-token"`
+	KeyFile                  string `yaml:"key_file"                      cli:"key-file"`
+	ListenClientURLs         string `yaml:"listen_client_urls"            cli:"listen-client-urls"`
+	ListenPeerURLs           string `yaml:"listen_peer_urls"              cli:"listen-peer-urls"`
+	LogPackageLevels         string `yaml:"log_package_levels"            cli:"log-package-levels"`
+	MaxSnapshots             int    `yaml:"max_snapshots"                 cli:"max-snapshots"`
+	MaxWALs                  int    `yaml:"max_wals"                      cli:"max-wals"`
+	Name                     string `yaml:"name"                          cli:"name"`
+	PeerCAFile               string `yaml:"peer_ca_file"                  cli:"peer-ca-file"                deprecated:"peer_ca_file obsoleted peer_trusted_ca_file and peer_client_cert_auth"`
+	PeerCertFile             string `yaml:"peer_cert_file"                cli:"peer-cert-file"`
+	PeerKeyFile              string `yaml:"peer_key_file"                 cli:"peer-key-file"`
+	PeerClientCertAuth       bool   `yaml:"peer_client_cert_auth"         cli:"peer-client-cert-auth"`
+	PeerTrustedCAFile        string `yaml:"peer_trusted_ca_file"          cli:"peer-trusted-ca-file"`
+	Proxy                    string `yaml:"proxy"                         cli:"proxy"                       valid:"^(on|off|readonly)$"`
+	ProxyDialTimeout         int    `yaml:"proxy_dial_timeout"            cli:"proxy-dial-timeout"`
+	ProxyFailureWait         int    `yaml:"proxy_failure_wait"            cli:"proxy-failure-wait"`
+	ProxyReadTimeout         int    `yaml:"proxy_read_timeout"            cli:"proxy-read-timeout"`
+	ProxyRefreshInterval     int    `yaml:"proxy_refresh_interval"        cli:"proxy-refresh-interval"`
+	ProxyWriteTimeout        int    `yaml:"proxy_write_timeout"           cli:"proxy-write-timeout"`
+	SnapshotCount            int    `yaml:"snapshot_count"                cli:"snapshot-count"`
+	StrictReconfigCheck      bool   `yaml:"strict_reconfig_check"         cli:"strict-reconfig-check"`
+	TrustedCAFile            string `yaml:"trusted_ca_file"               cli:"trusted-ca-file"`
+	WalDir                   string `yaml:"wal_dir"                       cli:"wal-dir"`
 }

--- a/config/types/flannel.go
+++ b/config/types/flannel.go
@@ -96,51 +96,51 @@ func init() {
 
 // flannelContents creates the string containing the systemd drop in for flannel
 func flannelContents(flannel Flannel) string {
-	vars := getEnvVars(flannel.Options)
-	// Add the tag
-	vars = append(vars, fmt.Sprintf("FLANNEL_IMAGE_TAG=v%s", flannel.Version))
-	return serviceContentsFromEnvVars(vars)
+	args := getCliArgs(flannel.Options)
+	vars := []string{fmt.Sprintf("FLANNEL_IMAGE_TAG=v%s", flannel.Version)}
+
+	return assembleUnit("/usr/lib/coreos/flannel-wrapper $FLANNEL_OPTS", args, vars)
 }
 
 // Flannel0_7 represents flannel options for version 0.7.x. Don't embed Flannel0_6 because
 // the yaml parser doesn't handle embedded structs
 type Flannel0_7 struct {
-	EtcdUsername  string `yaml:"etcd_username"   env:"FLANNELD_ETCD_USERNAME"`
-	EtcdPassword  string `yaml:"etcd_password"   env:"FLANNELD_ETCD_PASSWORD"`
-	EtcdEndpoints string `yaml:"etcd_endpoints"  env:"FLANNELD_ETCD_ENDPOINTS"`
-	EtcdCAFile    string `yaml:"etcd_cafile"     env:"FLANNELD_ETCD_CAFILE"`
-	EtcdCertFile  string `yaml:"etcd_certfile"   env:"FLANNELD_ETCD_CERTFILE"`
-	EtcdKeyFile   string `yaml:"etcd_keyfile"    env:"FLANNELD_ETCD_KEYFILE"`
-	EtcdPrefix    string `yaml:"etcd_prefix"     env:"FLANNELD_ETCD_PREFIX"`
-	IPMasq        string `yaml:"ip_masq"         env:"FLANNELD_IP_MASQ"`
-	SubnetFile    string `yaml:"subnet_file"     env:"FLANNELD_SUBNET_FILE"`
-	Iface         string `yaml:"interface"       env:"FLANNELD_IFACE"`
-	PublicIP      string `yaml:"public_ip"       env:"FLANNELD_PUBLIC_IP"`
-	KubeSubnetMgr bool   `yaml:"kube_subnet_mgr" env:"FLANNEL_KUBE_SUBNET_MGR"`
+	EtcdUsername  string `yaml:"etcd_username"   cli:"etcd-username"`
+	EtcdPassword  string `yaml:"etcd_password"   cli:"etcd-password"`
+	EtcdEndpoints string `yaml:"etcd_endpoints"  cli:"etcd-endpoints"`
+	EtcdCAFile    string `yaml:"etcd_cafile"     cli:"etcd-cafile"`
+	EtcdCertFile  string `yaml:"etcd_certfile"   cli:"etcd-certfile"`
+	EtcdKeyFile   string `yaml:"etcd_keyfile"    cli:"etcd-keyfile"`
+	EtcdPrefix    string `yaml:"etcd_prefix"     cli:"etcd-prefix"`
+	IPMasq        string `yaml:"ip_masq"         cli:"ip-masq"`
+	SubnetFile    string `yaml:"subnet_file"     cli:"subnet-file"`
+	Iface         string `yaml:"interface"       cli:"iface"`
+	PublicIP      string `yaml:"public_ip"       cli:"public-ip"`
+	KubeSubnetMgr bool   `yaml:"kube_subnet_mgr" cli:"kube-subnet-mgr"`
 }
 
 type Flannel0_6 struct {
-	EtcdUsername  string `yaml:"etcd_username"  env:"FLANNELD_ETCD_USERNAME"`
-	EtcdPassword  string `yaml:"etcd_password"  env:"FLANNELD_ETCD_PASSWORD"`
-	EtcdEndpoints string `yaml:"etcd_endpoints" env:"FLANNELD_ETCD_ENDPOINTS"`
-	EtcdCAFile    string `yaml:"etcd_cafile"    env:"FLANNELD_ETCD_CAFILE"`
-	EtcdCertFile  string `yaml:"etcd_certfile"  env:"FLANNELD_ETCD_CERTFILE"`
-	EtcdKeyFile   string `yaml:"etcd_keyfile"   env:"FLANNELD_ETCD_KEYFILE"`
-	EtcdPrefix    string `yaml:"etcd_prefix"    env:"FLANNELD_ETCD_PREFIX"`
-	IPMasq        string `yaml:"ip_masq"        env:"FLANNELD_IP_MASQ"`
-	SubnetFile    string `yaml:"subnet_file"    env:"FLANNELD_SUBNET_FILE"`
-	Iface         string `yaml:"interface"      env:"FLANNELD_IFACE"`
-	PublicIP      string `yaml:"public_ip"      env:"FLANNELD_PUBLIC_IP"`
+	EtcdUsername  string `yaml:"etcd_username"  cli:"etcd-username"`
+	EtcdPassword  string `yaml:"etcd_password"  cli:"etcd-password"`
+	EtcdEndpoints string `yaml:"etcd_endpoints" cli:"etcd-endpoints"`
+	EtcdCAFile    string `yaml:"etcd_cafile"    cli:"etcd-cafile"`
+	EtcdCertFile  string `yaml:"etcd_certfile"  cli:"etcd-certfile"`
+	EtcdKeyFile   string `yaml:"etcd_keyfile"   cli:"etcd-keyfile"`
+	EtcdPrefix    string `yaml:"etcd_prefix"    cli:"etcd-prefix"`
+	IPMasq        string `yaml:"ip_masq"        cli:"ip-masq"`
+	SubnetFile    string `yaml:"subnet_file"    cli:"subnet-file"`
+	Iface         string `yaml:"interface"      cli:"iface"`
+	PublicIP      string `yaml:"public_ip"      cli:"public-ip"`
 }
 
 type Flannel0_5 struct {
-	EtcdEndpoints string `yaml:"etcd_endpoints" env:"FLANNELD_ETCD_ENDPOINTS"`
-	EtcdCAFile    string `yaml:"etcd_cafile"    env:"FLANNELD_ETCD_CAFILE"`
-	EtcdCertFile  string `yaml:"etcd_certfile"  env:"FLANNELD_ETCD_CERTFILE"`
-	EtcdKeyFile   string `yaml:"etcd_keyfile"   env:"FLANNELD_ETCD_KEYFILE"`
-	EtcdPrefix    string `yaml:"etcd_prefix"    env:"FLANNELD_ETCD_PREFIX"`
-	IPMasq        string `yaml:"ip_masq"        env:"FLANNELD_IP_MASQ"`
-	SubnetFile    string `yaml:"subnet_file"    env:"FLANNELD_SUBNET_FILE"`
-	Iface         string `yaml:"interface"      env:"FLANNELD_IFACE"`
-	PublicIP      string `yaml:"public_ip"      env:"FLANNELD_PUBLIC_IP"`
+	EtcdEndpoints string `yaml:"etcd_endpoints" cli:"etcd-endpoints"`
+	EtcdCAFile    string `yaml:"etcd_cafile"    cli:"etcd-cafile"`
+	EtcdCertFile  string `yaml:"etcd_certfile"  cli:"etcd-certfile"`
+	EtcdKeyFile   string `yaml:"etcd_keyfile"   cli:"etcd-keyfile"`
+	EtcdPrefix    string `yaml:"etcd_prefix"    cli:"etcd-prefix"`
+	IPMasq        string `yaml:"ip_masq"        cli:"ip-masq"`
+	SubnetFile    string `yaml:"subnet_file"    cli:"subnet-file"`
+	Iface         string `yaml:"interface"      cli:"iface"`
+	PublicIP      string `yaml:"public_ip"      cli:"public-ip"`
 }


### PR DESCRIPTION
(This PR is based on https://github.com/coreos/container-linux-config-transpiler/pull/36, so ignore all but the final commit. Will rebase once that PR is merged)

This commit refactors the etcd and flannel logic to pass the arguments to the service via the command line instead of environment variables. This is necessary for the coreos-metadata templating logic in a following commit.