### PR TITLE
config: templating implemented for etcd and flannel sections

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,6 @@ func Parse(data []byte) (types.Config, report.Report) {
 	return cfg, r
 }
 
-func ConvertAs2_0(in types.Config) (ignTypes.Config, report.Report) {
-	return types.ConvertAs2_0(in)
+func ConvertAs2_0(in types.Config, platform string) (ignTypes.Config, report.Report) {
+	return types.ConvertAs2_0(in, platform)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1097,7 +1097,7 @@ func TestConvertAs2_0(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		cfg, r := ConvertAs2_0(test.in.cfg)
+		cfg, r := ConvertAs2_0(test.in.cfg, "")
 		if !reflect.DeepEqual(r, test.out.r) {
 			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.r, r)
 		}

--- a/config/templating/templating.go
+++ b/config/templating/templating.go
@@ -1,0 +1,128 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templating
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrUnknownPlatform = fmt.Errorf("unsupported platform")
+	ErrUnknownField    = fmt.Errorf("unknown field")
+)
+
+const (
+	PlatformAzure  = "azure"
+	PlatformDO     = "digitalocean"
+	PlatformEC2    = "ec2"
+	PlatformGCE    = "gce"
+	PlatformPacket = "packet"
+)
+
+var Platforms = []string{
+	PlatformAzure,
+	PlatformDO,
+	PlatformEC2,
+	PlatformGCE,
+	PlatformPacket,
+}
+
+const (
+	fieldHostname  = "HOSTNAME"
+	fieldV4Private = "PRIVATE_IPV4"
+	fieldV4Public  = "PUBLIC_IPV4"
+	fieldV6Private = "PRIVATE_IPV6"
+	fieldV6Public  = "PUBLIC_IPV6"
+)
+
+var platformTemplatingMap = map[string]map[string]string{
+	PlatformAzure: {
+		// TODO: is this right?
+		fieldV4Private: "COREOS_AZURE_IPV4_DYNAMIC",
+		fieldV4Public:  "COREOS_AZURE_IPV4_VIRTUAL",
+	},
+	PlatformDO: {
+		// TODO: unused: COREOS_DIGITALOCEAN_IPV4_ANCHOR_0
+		fieldHostname:  "COREOS_DIGITALOCEAN_HOSTNAME",
+		fieldV4Private: "COREOS_DIGITALOCEAN_IPV4_PRIVATE_0",
+		fieldV4Public:  "COREOS_DIGITALOCEAN_IPV4_PUBLIC_0",
+		fieldV6Private: "COREOS_DIGITALOCEAN_IPV6_PRIVATE_0",
+		fieldV6Public:  "COREOS_DIGITALOCEAN_IPV6_PUBLIC_0",
+	},
+	PlatformEC2: {
+		fieldHostname:  "COREOS_EC2_HOSTNAME",
+		fieldV4Private: "COREOS_EC2_IPV4_LOCAL",
+		fieldV4Public:  "COREOS_EC2_IPV4_PUBLIC",
+	},
+	PlatformGCE: {
+		fieldHostname:  "COREOS_GCE_HOSTNAME",
+		fieldV4Private: "COREOS_GCE_IP_EXTERNAL_0",
+		fieldV4Public:  "COREOS_GCE_IP_LOCAL_0",
+	},
+	PlatformPacket: {
+		fieldHostname:  "COREOS_PACKET_HOSTNAME",
+		fieldV4Private: "COREOS_PACKET_IPV4_PRIVATE_0",
+		fieldV4Public:  "COREOS_PACKET_IPV4_PUBLIC_0",
+		fieldV6Public:  "COREOS_PACKET_IPV6_PUBLIC_0",
+	},
+}
+
+// HasTemplating returns whether or not any of the environment variables present
+// in the passed in list use ct templating
+func HasTemplating(vars []string) bool {
+	for _, v := range vars {
+		if strings.ContainsRune(v, '{') || strings.ContainsRune(v, '}') {
+			return true
+		}
+	}
+	return false
+}
+
+func PerformTemplating(platform string, vars []string) ([]string, error) {
+	if _, ok := platformTemplatingMap[platform]; !ok {
+		return nil, ErrUnknownPlatform
+	}
+
+	for i := range vars {
+		startIndex := strings.IndexRune(vars[i], '{')
+		endIndex := strings.IndexRune(vars[i], '}')
+		for startIndex != -1 && endIndex != -1 && startIndex < endIndex {
+			fieldName := vars[i][startIndex+1 : endIndex]
+			fieldVal, ok := platformTemplatingMap[platform][fieldName]
+			if !ok {
+				return nil, ErrUnknownField
+			}
+			vars[i] = strings.Replace(vars[i], "{"+fieldName+"}", "${"+fieldVal+"}", 1)
+
+			// start the search for a new start index from the old end index, or
+			// we'll just find the curly braces we just substituted in
+			startIndex = strings.IndexRune(vars[i][endIndex:], '{')
+			if startIndex != -1 {
+				startIndex += endIndex
+
+				// and start the search for a new end index from the new start
+				// index, or as before we'll just find the curly braces we just
+				// substituted in
+				endIndex = strings.IndexRune(vars[i][startIndex:], '}')
+				if endIndex != -1 {
+					endIndex += startIndex
+				}
+			}
+
+		}
+	}
+	return vars, nil
+}

--- a/config/templating/templating_test.go
+++ b/config/templating/templating_test.go
@@ -1,0 +1,121 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templating
+
+import (
+	"testing"
+)
+
+func TestHasTemplating(t *testing.T) {
+	type in struct {
+		vars []string
+	}
+	type out struct {
+		hasTemplating bool
+	}
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in{[]string{"foo=BAR"}},
+			out{false},
+		},
+		{
+			in{[]string{"foo={PUBLIC_IPV4}"}},
+			out{true},
+		},
+		{
+			in{[]string{"foo=PUBLIC_IPV4}"}},
+			out{true},
+		},
+		{
+			in{[]string{"foo={PUBLIC_IPV4"}},
+			out{true},
+		},
+		{
+			in{[]string{"foo=}PUBLIC_IPV4{"}},
+			out{true},
+		},
+	}
+	for i, test := range tests {
+		if test.out.hasTemplating != HasTemplating(test.in.vars) {
+			t.Errorf("#%d: hasTemplating didn't match", i)
+		}
+	}
+}
+
+func TestPerformTemplating(t *testing.T) {
+	type in struct {
+		platform string
+		vars     []string
+	}
+	type out struct {
+		vars []string
+		err  error
+	}
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in{platform: "aws"},
+			out{err: ErrUnknownPlatform},
+		},
+		{
+			in{platform: "ec2", vars: []string{"foo", "bar"}},
+			out{vars: []string{"foo", "bar"}},
+		},
+		{
+			in{platform: "ec2", vars: []string{"foo: {HOSTNAME}", "bar"}},
+			out{vars: []string{"foo: ${COREOS_EC2_HOSTNAME}", "bar"}},
+		},
+		{
+			in{platform: "digitalocean", vars: []string{"foo: {PRIVATE_IPV4}", "bar"}},
+			out{vars: []string{"foo: ${COREOS_DIGITALOCEAN_IPV4_PRIVATE_0}", "bar"}},
+		},
+		{
+			in{platform: "digitalocean", vars: []string{"foo: {PRIVATE_IPV4} {PUBLIC_IPV4}", "bar"}},
+			out{vars: []string{"foo: ${COREOS_DIGITALOCEAN_IPV4_PRIVATE_0} ${COREOS_DIGITALOCEAN_IPV4_PUBLIC_0}", "bar"}},
+		},
+		{
+			in{platform: "azure", vars: []string{"foo: }HOSTNAME{", "bar"}},
+			out{vars: []string{"foo: }HOSTNAME{", "bar"}},
+		},
+		{
+			in{platform: "packet", vars: []string{"foo: {BAZ}", "bar"}},
+			out{err: ErrUnknownField},
+		},
+	}
+	for i, test := range tests {
+		outVars, err := PerformTemplating(test.in.platform, test.in.vars)
+		if err != test.out.err {
+			t.Errorf("#%d: err (%v) didn't match expectedErr (%v)", i, err, test.out.err)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		if len(outVars) != len(test.in.vars) {
+			t.Errorf("#%d: length of vars changed, was %d and is now %d", i, len(test.in.vars), len(outVars))
+			continue
+		}
+		for j := range outVars {
+			if test.out.vars[j] != outVars[j] {
+				t.Errorf("#%d: var %d didn't match expected result, got %q, expected %q", i, j, outVars[j], test.out.vars[j])
+			}
+		}
+	}
+}

--- a/config/types/config.go
+++ b/config/types/config.go
@@ -47,7 +47,7 @@ type ConfigReference struct {
 }
 
 func init() {
-	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
 		for _, ref := range in.Ignition.Config.Append {
 			newRef, err := convertConfigReference(ref)
 			if err != nil {

--- a/config/types/converter.go
+++ b/config/types/converter.go
@@ -22,7 +22,7 @@ import (
 	"github.com/coreos/ignition/config/validate/report"
 )
 
-type converterFor2_0 func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report)
+type converterFor2_0 func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report)
 
 var convertersFor2_0 []converterFor2_0
 
@@ -30,7 +30,7 @@ func register2_0(f converterFor2_0) {
 	convertersFor2_0 = append(convertersFor2_0, f)
 }
 
-func ConvertAs2_0(in Config) (ignTypes.Config, report.Report) {
+func ConvertAs2_0(in Config, platform string) (ignTypes.Config, report.Report) {
 	out := ignTypes.Config{
 		Ignition: ignTypes.Ignition{
 			Version: ignTypes.IgnitionVersion{Major: 2, Minor: 0},
@@ -41,7 +41,7 @@ func ConvertAs2_0(in Config) (ignTypes.Config, report.Report) {
 
 	for _, convert := range convertersFor2_0 {
 		var subReport report.Report
-		out, subReport = convert(in, out)
+		out, subReport = convert(in, out, platform)
 		r.Merge(subReport)
 	}
 	if r.IsFatal() {

--- a/config/types/disks.go
+++ b/config/types/disks.go
@@ -41,7 +41,7 @@ type Partition struct {
 }
 
 func init() {
-	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
 		for _, disk := range in.Storage.Disks {
 			newDisk := ignTypes.Disk{
 				Device:    ignTypes.Path(disk.Device),

--- a/config/types/files.go
+++ b/config/types/files.go
@@ -51,7 +51,7 @@ type FileGroup struct {
 }
 
 func init() {
-	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
 		for _, file := range in.Storage.Files {
 			newFile := ignTypes.File{
 				Filesystem: file.Filesystem,

--- a/config/types/filesystems.go
+++ b/config/types/filesystems.go
@@ -37,7 +37,7 @@ type Create struct {
 }
 
 func init() {
-	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
 		for _, filesystem := range in.Storage.Filesystems {
 			newFilesystem := ignTypes.Filesystem{
 				Name: filesystem.Name,

--- a/config/types/networkd.go
+++ b/config/types/networkd.go
@@ -29,7 +29,7 @@ type NetworkdUnit struct {
 }
 
 func init() {
-	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
 		for _, unit := range in.Networkd.Units {
 			out.Networkd.Units = append(out.Networkd.Units, ignTypes.NetworkdUnit{
 				Name:     ignTypes.NetworkdUnitName(unit.Name),

--- a/config/types/passwd.go
+++ b/config/types/passwd.go
@@ -52,7 +52,7 @@ type Group struct {
 }
 
 func init() {
-	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
 		for _, user := range in.Passwd.Users {
 			newUser := ignTypes.User{
 				Name:              user.Name,

--- a/config/types/raid.go
+++ b/config/types/raid.go
@@ -27,7 +27,7 @@ type Raid struct {
 }
 
 func init() {
-	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
 		for _, array := range in.Storage.Arrays {
 			newArray := ignTypes.Raid{
 				Name:   array.Name,

--- a/config/types/systemd.go
+++ b/config/types/systemd.go
@@ -37,7 +37,7 @@ type SystemdUnitDropIn struct {
 }
 
 func init() {
-	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
 		for _, unit := range in.Systemd.Units {
 			newUnit := ignTypes.SystemdUnit{
 				Name:     ignTypes.SystemdUnitName(unit.Name),

--- a/config/types/update.go
+++ b/config/types/update.go
@@ -58,7 +58,7 @@ func (s UpdateServer) Validate() report.Report {
 }
 
 func init() {
-	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
 		if in.Update != nil {
 			out.Storage.Files = append(out.Storage.Files, ignTypes.File{
 				Filesystem: "root",

--- a/internal/main.go
+++ b/internal/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/coreos/container-linux-config-transpiler/config"
+	"github.com/coreos/container-linux-config-transpiler/config/templating"
 	"github.com/coreos/container-linux-config-transpiler/version"
 )
 
@@ -33,12 +34,13 @@ func stderr(f string, a ...interface{}) {
 
 func main() {
 	flags := struct {
-		help    bool
-		pretty  bool
-		version bool
-		inFile  string
-		outFile string
-		strict  bool
+		help     bool
+		pretty   bool
+		version  bool
+		inFile   string
+		outFile  string
+		strict   bool
+		platform string
 	}{}
 
 	flag.BoolVar(&flags.help, "help", false, "Print help and exit.")
@@ -47,6 +49,7 @@ func main() {
 	flag.StringVar(&flags.inFile, "in-file", "", "Path to the container linux config. Standard input unless specified otherwise.")
 	flag.StringVar(&flags.outFile, "out-file", "", "Path to the resulting Ignition config. Standard output unless specified otherwies.")
 	flag.BoolVar(&flags.strict, "strict", false, "Fail if any warnings are encountered.")
+	flag.StringVar(&flags.platform, "platform", "", fmt.Sprintf("Platform to target. Accepted values: %v.", templating.Platforms))
 
 	flag.Parse()
 
@@ -98,7 +101,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	ignCfg, report := config.ConvertAs2_0(cfg)
+	ignCfg, report := config.ConvertAs2_0(cfg, flags.platform)
 	stderr(report.String())
 	if report.IsFatal() {
 		stderr("Generated Ignition config was invalid.")


### PR DESCRIPTION
(This PR is based on https://github.com/coreos/container-linux-config-transpiler/pull/38, so ignore all but the final commit. Will rebase once that PR is merged)

Users can now use `{}` to refer to dynamic information (like public ipv4
address) that will be filled in via an environment variable populated by
the coreos metadata service (which is also enabled and added as a
requirement if templating is used).

This is notably only usable inside the etcd and flannel sections. I could enable it in other places like systemd units, if we think it wouldn't be too confusing.

This commit also needs documentation to be written for it, but I'm holding off on doing that until https://github.com/coreos/container-linux-config-transpiler/pull/37 gets merged.

Example usage: https://gist.github.com/dgonyeo/cf500f91574fbc4441f6c346e43b89d0

Fixes https://github.com/coreos/bugs/issues/1821