### PR TITLE
 config/types/update: can now configure update group and server

### DIFF
--- a/config/types/config.go
+++ b/config/types/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Passwd   Passwd   `yaml:"passwd"`
 	Etcd     *Etcd    `yaml:"etcd"`
 	Flannel  *Flannel `yaml:"flannel"`
+	Update   *Update  `yaml:"update"`
 }
 
 type Ignition struct {

--- a/config/types/update.go
+++ b/config/types/update.go
@@ -1,0 +1,88 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	ignTypes "github.com/coreos/ignition/config/v2_0/types"
+	"github.com/coreos/ignition/config/validate/report"
+	"github.com/vincent-petithory/dataurl"
+)
+
+var (
+	ErrUnknownGroup = errors.New("unknown update group")
+)
+
+type Update struct {
+	Group  UpdateGroup  `yaml:"group"`
+	Server UpdateServer `yaml:"server"`
+}
+
+type UpdateGroup string
+type UpdateServer string
+
+func (u Update) Validate() report.Report {
+	switch strings.ToLower(string(u.Group)) {
+	case "stable", "beta", "alpha":
+		return report.Report{}
+	default:
+		if u.Server == "" {
+			return report.ReportFromError(ErrUnknownGroup, report.EntryWarning)
+		}
+		return report.Report{}
+	}
+}
+
+func (s UpdateServer) Validate() report.Report {
+	_, err := url.Parse(string(s))
+	if err != nil {
+		return report.ReportFromError(err, report.EntryError)
+	}
+	return report.Report{}
+}
+
+func init() {
+	register2_0(func(in Config, out ignTypes.Config) (ignTypes.Config, report.Report) {
+		if in.Update != nil {
+			out.Storage.Files = append(out.Storage.Files, ignTypes.File{
+				Filesystem: "root",
+				Path:       "/etc/coreos/update.conf",
+				Mode:       0644,
+				Contents: ignTypes.FileContents{
+					Source: ignTypes.Url{
+						Scheme: "data",
+						Opaque: "," + updateConfContents(in.Update),
+					},
+				},
+			})
+		}
+		return out, report.Report{}
+	})
+}
+
+func updateConfContents(u *Update) string {
+	var res string
+	if u.Group != "" {
+		res = fmt.Sprintf("GROUP=%s", strings.ToLower(string(u.Group)))
+	}
+	if u.Server != "" {
+		res += fmt.Sprintf("\nSERVER=%s", u.Server)
+	}
+	return dataurl.EscapeString(res)
+}

--- a/config/types/update_test.go
+++ b/config/types/update_test.go
@@ -1,0 +1,44 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/ignition/config/validate/report"
+)
+
+func TestValidateUpdateGroup(t *testing.T) {
+	tests := []struct {
+		in  string
+		out report.Report
+	}{
+		{"stable", report.Report{}},
+		{"beta", report.Report{}},
+		{"alpha", report.Report{}},
+		{
+			"super-alpha",
+			report.ReportFromError(ErrUnknownGroup, report.EntryWarning),
+		},
+	}
+
+	for i, test := range tests {
+		r := Update{Group: UpdateGroup(test.in)}.Validate()
+		if !reflect.DeepEqual(test.out, r) {
+			t.Errorf("#%d: wanted %v, got %v", i, test.out, r)
+		}
+	}
+}


### PR DESCRIPTION
(This PR is based on #36, so ignore all but the final commit. Will rebase once that PR is merged)

This commit lets users configure the update group and server for a machine:
```
update:
    channel: beta
    server: https://public.update.core-os.net/v1/update/
```

A resulting ignition config is viewable here (ignore the strategy bit): https://gist.github.com/dgonyeo/9f98a88353dbae078c66eb9487206919

There was no documentation on this config file that I could find, so someone should sanity check it for me.

Fixes https://github.com/coreos/bugs/issues/1861.

This new feature needs documentation, waiting on https://github.com/coreos/container-linux-config-transpiler/pull/37 to be merged before I write it.