### PR TITLE
config: added sugar for iptables

### DIFF
--- a/config/types/config.go
+++ b/config/types/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Update    *Update    `yaml:"update"`
 	Docker    *Docker    `yaml:"docker"`
 	Locksmith *Locksmith `yaml:"locksmith"`
+	Iptables  *Iptables  `yaml:"iptables"`
 }
 
 type Ignition struct {

--- a/config/types/iptables.go
+++ b/config/types/iptables.go
@@ -1,0 +1,139 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"errors"
+	"fmt"
+
+	ignTypes "github.com/coreos/ignition/config/v2_0/types"
+	"github.com/coreos/ignition/config/validate/report"
+	"github.com/vincent-petithory/dataurl"
+)
+
+var (
+	ErrInvalidIptablesDefault = errors.New("iptables chain default must be one of ACCEPT or DROP")
+	ErrEmptyTableName         = errors.New("table cannot be empty")
+)
+
+type Iptables struct {
+	V4 []iptablesTable `yaml:"v4"`
+	V6 []iptablesTable `yaml:"v6"`
+}
+
+type iptablesTable struct {
+	Table   string         `yaml:"table"`
+	Input   *iptablesRules `yaml:"input"`
+	Forward *iptablesRules `yaml:"forward"`
+	Output  *iptablesRules `yaml:"output"`
+}
+
+type iptablesRules struct {
+	Default iptablesDefault `yaml:"default"`
+	Rules   []string        `yaml:"rules"`
+}
+
+type iptablesDefault string
+
+func (id iptablesDefault) Validate() report.Report {
+	switch id {
+	case "ACCEPT", "DROP", "":
+		return report.Report{}
+	default:
+		return report.ReportFromError(ErrInvalidIptablesDefault, report.EntryError)
+	}
+}
+
+func (it iptablesTable) Validate() report.Report {
+	if it.Table == "" {
+		return report.ReportFromError(ErrEmptyTableName, report.EntryError)
+	}
+	return report.Report{}
+}
+
+func init() {
+	register2_0(func(in Config, out ignTypes.Config, platform string) (ignTypes.Config, report.Report) {
+		if in.Iptables == nil {
+			return out, report.Report{}
+		}
+		if len(in.Iptables.V4) > 0 {
+			out.Storage.Files = append(out.Storage.Files, ignTypes.File{
+				Filesystem: "root",
+				Path:       "/var/lib/iptables/rules-save",
+				Mode:       0420,
+				Contents:   iptablesContents(in.Iptables.V4),
+			})
+			out.Systemd.Units = append(out.Systemd.Units, ignTypes.SystemdUnit{
+				Name:   "iptables-restore.service",
+				Enable: true,
+			})
+			out.Systemd.Units = append(out.Systemd.Units, ignTypes.SystemdUnit{
+				Name:   "iptables-store.service",
+				Enable: true,
+			})
+		}
+		if len(in.Iptables.V6) > 0 {
+			out.Storage.Files = append(out.Storage.Files, ignTypes.File{
+				Filesystem: "root",
+				Path:       "/var/lib/ip6tables/rules-save",
+				Mode:       0420,
+				Contents:   iptablesContents(in.Iptables.V6),
+			})
+			out.Systemd.Units = append(out.Systemd.Units, ignTypes.SystemdUnit{
+				Name:   "ip6tables-restore.service",
+				Enable: true,
+			})
+			out.Systemd.Units = append(out.Systemd.Units, ignTypes.SystemdUnit{
+				Name:   "ip6tables-store.service",
+				Enable: true,
+			})
+		}
+		return out, report.Report{}
+	})
+}
+
+func iptablesContents(chains []iptablesTable) ignTypes.FileContents {
+	contents := ""
+	for _, c := range chains {
+		contents += fmt.Sprintf("*%s\n", c.Table)
+		for _, s := range []struct {
+			Name string
+			r    *iptablesRules
+		}{
+			{"INPUT", c.Input},
+			{"FORWARD", c.Forward},
+			{"OUTPUT", c.Output},
+		} {
+			if s.r == nil {
+				continue
+			}
+			if s.r.Default == "" {
+				s.r.Default = "DROP"
+			}
+			contents += fmt.Sprintf(":%s %s [0:0]\n", s.Name, s.r.Default)
+			for _, r := range s.r.Rules {
+				contents += fmt.Sprintf("%s\n", r)
+			}
+		}
+	}
+	contents += "COMMIT\n# EOF\n"
+	fmt.Printf("rules:\n%s\n", contents)
+	return ignTypes.FileContents{
+		Source: ignTypes.Url{
+			Scheme: "data",
+			Opaque: "," + dataurl.EscapeString(contents),
+		},
+	}
+}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -111,6 +111,18 @@ _Note: all fields are optional unless otherwise marked_
   * **etcd_cafile** (string): the tls CA file to use when communicating with etcd
   * **etcd_certfile** (string): the tls cert file to use when communicating with etcd
   * **etcd_keyfile** (string): the tls key file to use when communicating with etcd
+* **iptables** (object): describes iptables rules for the machine to follow
+  * **v4** (list of objects): a list of tables and their rules
+    * **table** (string, required): the table these rules will go in
+    * **input** (object): the default and rules for the input chain
+      * **default** (string): the default policy of this chain, must be one of ACCEPT or DROP
+      * **rules** (list of strings): the iptables rules
+    * **forward** (object): the default and rules for the forward chain
+      * has the same fields as **input**
+    * **output** (object): the default and rules for the output chain
+      * has the same fields as **input**
+  * **v6**
+    * has the same fields as **v4**
 
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -185,6 +185,33 @@ locksmith:
 
 This example configures the Container Linux instance to be a member of the beta group, configures locksmithd to acquire a lock in etcd before rebooting for an update, and only allows reboots during a 2 hour window starting at 1 AM on Sundays.
 
+## iptables
+
+```yaml
+iptables:
+  v4:
+    - table: "filter"
+      output:
+        default: "ACCEPT"
+        rules:
+          - -A INPUT -i lo -j ACCEPT
+          - -A INPUT -i eth1 -j ACCEPT
+          - -A INPUT -p tcp -m tcp --dport 222 -j ACCEPT
+          - -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+  v6:
+    - table: "filter"
+      forward:
+        default: "ACCEPT"
+```
+
+This example configures all outbound IPv4 traffic to be accepted if it's going
+out on interfaces lo or eth1, if it's going to port 222, or if it's an already
+established connection, otherwise the traffic is dropped.
+
+Additionally all forwarding IPv6 traffic will be accepted.
+
+All other traffic will be dropped (including all incoming connections).
+
 [spec]: configuration.md
 [dropins]: https://coreos.com/os/docs/latest/using-systemd-drop-in-units.html
 [networkd]: https://coreos.com/os/docs/latest/network-config-with-networkd.html


### PR DESCRIPTION
Allows configs to specify iptables rules such as:

```yaml
iptables:
    v4:
        output:
            default: "ACCEPT"
            rules:
                - -A INPUT -i lo -j ACCEPT
                - -A INPUT -i eth1 -j ACCEPT
                - -A INPUT -p tcp -m tcp --dport 222 -j ACCEPT
                - -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
                - -A INPUT -p ipv6-icmp -j ACCEPT
    v6:
        forward:
            default: "ACCEPT"
```

From this config the iptables save files are generated, and then
`ip(6)tables-store.service` and `ip(6)tables-restore.service` are enabled.

Fixes https://github.com/coreos/bugs/issues/1845 (and for that cc @euank)

One caveat is that once this section is enabled all chains default to `DENY`, and I don't know if it would make more sense to have the output chain default to `ACCEPT`.

Waiting on https://github.com/coreos/container-linux-config-transpiler/pull/37 being merged to write docs.