### PR TITLE
config/types/locksmith: added configuration for locksmith reboot strat

### DIFF
--- a/config/types/config.go
+++ b/config/types/config.go
@@ -22,15 +22,16 @@ import (
 )
 
 type Config struct {
-	Ignition Ignition `yaml:"ignition"`
-	Storage  Storage  `yaml:"storage"`
-	Systemd  Systemd  `yaml:"systemd"`
-	Networkd Networkd `yaml:"networkd"`
-	Passwd   Passwd   `yaml:"passwd"`
-	Etcd     *Etcd    `yaml:"etcd"`
-	Flannel  *Flannel `yaml:"flannel"`
-	Update   *Update  `yaml:"update"`
-	Docker   *Docker  `yaml:"docker"`
+	Ignition  Ignition   `yaml:"ignition"`
+	Storage   Storage    `yaml:"storage"`
+	Systemd   Systemd    `yaml:"systemd"`
+	Networkd  Networkd   `yaml:"networkd"`
+	Passwd    Passwd     `yaml:"passwd"`
+	Etcd      *Etcd      `yaml:"etcd"`
+	Flannel   *Flannel   `yaml:"flannel"`
+	Update    *Update    `yaml:"update"`
+	Docker    *Docker    `yaml:"docker"`
+	Locksmith *Locksmith `yaml:"locksmith"`
 }
 
 type Ignition struct {

--- a/config/types/locksmith.go
+++ b/config/types/locksmith.go
@@ -1,0 +1,41 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/coreos/ignition/config/validate/report"
+)
+
+var (
+	ErrUnknownStrategy = errors.New("unknown reboot strategy")
+)
+
+type Locksmith struct {
+	RebootStrategy RebootStrategy `yaml:"reboot-strategy"`
+}
+
+type RebootStrategy string
+
+func (r RebootStrategy) Validate() report.Report {
+	switch strings.ToLower(string(r)) {
+	case "reboot", "etcd-lock", "off":
+		return report.Report{}
+	default:
+		return report.ReportFromError(ErrUnknownStrategy, report.EntryError)
+	}
+}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -139,6 +139,11 @@ docker:
   flags:
     - --config-file=/etc/docker/daemon.json
     - --default-gateway=172.16.0.1
+update:
+  group:  "alpha"
+  server: "https://public.update.core-os.net/v1/update/"
+locksmith:
+  reboot-strategy: "etcd-lock"
 ```
 
 _Note: all fields are optional unless otherwise marked_
@@ -238,6 +243,11 @@ _Note: all fields are optional unless otherwise marked_
   * **_other options_** (string): this section accepts any valid flannel options for the version of flannel specified. For a comprehensive list, please consult flannel's documentation. Note all options here should be in snake_case, not spine-case.
 * **docker**
   * **flags** (list of strings): additional flags to pass to the docker daemon when it is started
+* **update**
+  * **group** (string): the update group to follow. Most users will want one of: stable, beta, alpha.
+  * **server** (string): the server to fetch updates from.
+* **locksmith**
+  * **reboot-strategy** (string): the reboot strategy for locksmithd to follow. Must be one of: reboot, etcd-lock, off.
 
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397


### PR DESCRIPTION
Mostly a continuation of https://github.com/coreos/container-linux-config-transpiler/pull/40

Waiting on https://github.com/coreos/container-linux-config-transpiler/pull/37 to be merged before I write the docs