### PR TITLE
config/templating: added support for dynamic data in openstack-metadata

### DIFF
--- a/config/templating/templating.go
+++ b/config/templating/templating.go
@@ -25,11 +25,12 @@ var (
 )
 
 const (
-	PlatformAzure  = "azure"
-	PlatformDO     = "digitalocean"
-	PlatformEC2    = "ec2"
-	PlatformGCE    = "gce"
-	PlatformPacket = "packet"
+	PlatformAzure             = "azure"
+	PlatformDO                = "digitalocean"
+	PlatformEC2               = "ec2"
+	PlatformGCE               = "gce"
+	PlatformPacket            = "packet"
+	PlatformOpenStackMetadata = "openstack-metadata"
 )
 
 var Platforms = []string{
@@ -38,6 +39,7 @@ var Platforms = []string{
 	PlatformEC2,
 	PlatformGCE,
 	PlatformPacket,
+	PlatformOpenStackMetadata,
 }
 
 const (
@@ -77,6 +79,11 @@ var platformTemplatingMap = map[string]map[string]string{
 		fieldV4Private: "COREOS_PACKET_IPV4_PRIVATE_0",
 		fieldV4Public:  "COREOS_PACKET_IPV4_PUBLIC_0",
 		fieldV6Public:  "COREOS_PACKET_IPV6_PUBLIC_0",
+	},
+	PlatformOpenStackMetadata: {
+		fieldHostname:  "COREOS_OPENSTACK_HOSTNAME",
+		fieldV4Private: "COREOS_OPENSTACK_IPV4_LOCAL",
+		fieldV4Public:  "COREOS_OPENSTACK_IPV4_PUBLIC",
 	},
 }
 

--- a/doc/dynamic-data.md
+++ b/doc/dynamic-data.md
@@ -14,13 +14,14 @@ The available information varies by provider, and is expressed in different vari
 
 This is the information available in each provider.
 
-|                | Azure | Digital Ocean | EC2 | GCE | Packet |
-|----------------|-------|---------------|-----|-----|--------|
-| `HOSTNAME`     |       | ✓             | ✓   | ✓   | ✓      |
-| `PRIVATE_IPV4` | ✓     | ✓             | ✓   | ✓   | ✓      |
-| `PUBLIC_IPV4`  | ✓     | ✓             | ✓   | ✓   |        |
-| `PRIVATE_IPV6` |       | ✓             |     |     | ✓      |
-| `PUBLIC_IPV6`  |       | ✓             |     |     | ✓      |
+|                    | `HOSTNAME` | `PRIVATE_IPV4` | `PUBLIC_IPV4` | `PRIVATE_IPV6` | `PUBLIC_IPV6` |
+|--------------------|------------|----------------|---------------|----------------|---------------|
+| Azure              |            | ✓              | ✓             |                |               |
+| Digital Ocean      | ✓          | ✓              | ✓             | ✓              | ✓             |
+| EC2                | ✓          | ✓              | ✓             |                |               |
+| GCE                | ✓          | ✓              | ✓             |                |               |
+| Packet             | ✓          | ✓              | ✓             |                | ✓             |
+| OpenStack-Metadata | ✓          | ✓              | ✓             |                |               |
 
 ## Behind the scenes
 


### PR DESCRIPTION
Because the openstack-metadata support in coreos-metadata was in progress when I initially wrote the templating logic in ct, I forgot to include support for it.

This commit adds in support for using coreos-metadata with the openstack metadata service for dynamic data in CLCs.

This commit also flips the rows and columns in the dynamic data support table in the docs, so it's easier to grow (and adds openstack-metadata).