### PR TITLE
config/types/locksmith: add missing fields

### DIFF
--- a/config/types/common.go
+++ b/config/types/common.go
@@ -65,8 +65,7 @@ func assembleUnit(exec string, args, vars []string, platform string) (string, er
 	return out, nil
 }
 
-// getCliArgs builds a list of --ARG=VAL from a struct with cli: tags on its members.
-func getCliArgs(e interface{}) []string {
+func getArgs(format, tagName string, e interface{}) []string {
 	if e == nil {
 		return nil
 	}
@@ -79,11 +78,16 @@ func getCliArgs(e interface{}) []string {
 			if et.Field(i).Anonymous {
 				vars = append(vars, getCliArgs(val)...)
 			} else {
-				key := et.Field(i).Tag.Get("cli")
-				vars = append(vars, fmt.Sprintf("--%s=%q", key, val))
+				key := et.Field(i).Tag.Get(tagName)
+				vars = append(vars, fmt.Sprintf(format, key, val))
 			}
 		}
 	}
 
 	return vars
+}
+
+// getCliArgs builds a list of --ARG=VAL from a struct with cli: tags on its members.
+func getCliArgs(e interface{}) []string {
+	return getArgs("--%s=%q", "cli", e)
 }

--- a/config/types/locksmith.go
+++ b/config/types/locksmith.go
@@ -16,20 +16,47 @@ package types
 
 import (
 	"errors"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/coreos/ignition/config/validate/report"
 )
 
 var (
-	ErrUnknownStrategy = errors.New("unknown reboot strategy")
+	ErrMissingStartOrLength = errors.New("window-start and window-length must both be specified")
+	ErrUnknownStrategy      = errors.New("unknown reboot strategy")
+	ErrParsingWindowStart   = errors.New("couldn't parse window start")
+	ErrUnknownDay           = errors.New("unknown day in window start")
+	ErrParsingWindow        = errors.New("couldn't parse window start")
+	ErrParsingLength        = errors.New("couldn't parse window length")
 )
 
 type Locksmith struct {
-	RebootStrategy RebootStrategy `yaml:"reboot_strategy"`
+	RebootStrategy RebootStrategy `yaml:"reboot_strategy" locksmith:"REBOOT_STRATEGY"`
+	WindowStart    WindowStart    `yaml:"window_start"    locksmith:"LOCKSMITHD_REBOOT_WINDOW_START"`
+	WindowLength   WindowLength   `yaml:"window_length"   locksmith:"LOCKSMITHD_REBOOT_WINDOW_LENGTH"`
+	Group          string         `yaml:"group"           locksmith:"LOCKSMITHD_GROUP"`
+	EtcdEndpoints  string         `yaml:"etcd_endpoints"  locksmith:"LOCKSMITHD_ENDPOINTS"`
+	EtcdCAFile     string         `yaml:"etcd_cafile"     locksmith:"LOCKSMITHD_ETCD_CAFILE"`
+	EtcdCertFile   string         `yaml:"etcd_certfile"   locksmith:"LOCKSMITHD_ETCD_CERTFILE"`
+	EtcdKeyFile    string         `yaml:"etcd_keyfile"    locksmith:"LOCKSMITHD_ETCD_KEYFILE"`
+}
+
+func (l Locksmith) configLines() []string {
+	return getArgs("%s=%q", "locksmith", l)
 }
 
 type RebootStrategy string
+type WindowStart string
+type WindowLength string
+
+func (l Locksmith) Validate() report.Report {
+	if (l.WindowStart != "" && l.WindowLength == "") || (l.WindowStart == "" && l.WindowLength != "") {
+		return report.ReportFromError(ErrMissingStartOrLength, report.EntryError)
+	}
+	return report.Report{}
+}
 
 func (r RebootStrategy) Validate() report.Report {
 	switch strings.ToLower(string(r)) {
@@ -38,4 +65,43 @@ func (r RebootStrategy) Validate() report.Report {
 	default:
 		return report.ReportFromError(ErrUnknownStrategy, report.EntryError)
 	}
+}
+
+func (s WindowStart) Validate() report.Report {
+	if s == "" {
+		return report.Report{}
+	}
+	var day string
+	var t string
+
+	_, err := fmt.Sscanf(string(s), "%s %s", &day, &t)
+	if err != nil {
+		day = "not-present"
+		t = string(s)
+	}
+
+	switch strings.ToLower(day) {
+	case "sun", "mon", "tue", "wed", "thu", "fri", "sat", "not-present":
+		break
+	default:
+		return report.ReportFromError(ErrUnknownDay, report.EntryError)
+	}
+
+	_, err = time.Parse("15:04", t)
+	if err != nil {
+		return report.ReportFromError(ErrParsingWindow, report.EntryError)
+	}
+
+	return report.Report{}
+}
+
+func (l WindowLength) Validate() report.Report {
+	if l == "" {
+		return report.Report{}
+	}
+	_, err := time.ParseDuration(string(l))
+	if err != nil {
+		return report.ReportFromError(ErrParsingLength, report.EntryError)
+	}
+	return report.Report{}
 }

--- a/config/types/locksmith_test.go
+++ b/config/types/locksmith_test.go
@@ -1,0 +1,62 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/ignition/config/validate/report"
+)
+
+func TestValidateWindowStart(t *testing.T) {
+	type in struct {
+		start string
+	}
+	type out struct {
+		r report.Report
+	}
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{in{"mon 00:00"}, out{report.Report{}}},
+		{in{"tue 23:59"}, out{report.Report{}}},
+		{in{"sun 12:00"}, out{report.Report{}}},
+		{
+			in{"mon00:00"},
+			out{report.ReportFromError(ErrParsingWindow, report.EntryError)},
+		},
+		{
+			in{"foo 00:00"},
+			out{report.ReportFromError(ErrUnknownDay, report.EntryError)},
+		},
+		{
+			in{"mon 0000"},
+			out{report.ReportFromError(ErrParsingWindow, report.EntryError)},
+		},
+		{
+			in{"mon 24:00"},
+			out{report.ReportFromError(ErrParsingWindow, report.EntryError)},
+		},
+	}
+
+	for i, test := range tests {
+		r := WindowStart(test.in.start).Validate()
+		if !reflect.DeepEqual(test.out.r, r) {
+			t.Errorf("#%d: wanted %v, got %v", i, test.out.r, r)
+		}
+	}
+}

--- a/config/types/update.go
+++ b/config/types/update.go
@@ -69,8 +69,9 @@ func init() {
 			}
 		}
 		if in.Locksmith != nil {
-			if in.Locksmith.RebootStrategy != "" {
-				contents += fmt.Sprintf("\nREBOOT_STRATEGY=%s", strings.ToLower(string(in.Locksmith.RebootStrategy)))
+			lines := in.Locksmith.configLines()
+			if len(lines) > 0 {
+				contents += "\n" + strings.Join(lines, "\n")
 			}
 		}
 		if contents != "" {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -144,6 +144,13 @@ update:
   server: "https://public.update.core-os.net/v1/update/"
 locksmith:
   reboot_strategy: "etcd-lock"
+  window_start:    "Mon 2:00"
+  window_length:   "2h25m3s"
+  group:           "load balancers"
+  etcd_endpoints:  "https://172.16.0.101:2379,https://172.16.0.102:2379,https://172.16.0.103:2379"
+  etcd_cafile:     "/etc/ssl/etcd/ca.pem"
+  etcd_certfile:   "/etc/ssl/etcd/client.pem"
+  etcd_keyfile:    "/etc/ssl/etcd/client-key.pem"
 ```
 
 _Note: all fields are optional unless otherwise marked_
@@ -248,6 +255,13 @@ _Note: all fields are optional unless otherwise marked_
   * **server** (string): the server to fetch updates from.
 * **locksmith**
   * **reboot_strategy** (string): the reboot strategy for locksmithd to follow. Must be one of: reboot, etcd-lock, off.
+  * **window_start** (string, required if window-length isn't empty): the start of the window that locksmithd can reboot the machine during
+  * **window_length** (string, required if window-start isn't empty): the duration of the window that locksmithd can reboot the machine during
+  * **group** (string): the locksmith etcd group to be part of for reboot control
+  * **etcd_endpoints** (string): the endpoints of etcd locksmith should use
+  * **etcd_cafile** (string): the tls CA file to use when communicating with etcd
+  * **etcd_certfile** (string): the tls cert file to use when communicating with etcd
+  * **etcd_keyfile** (string): the tls key file to use when communicating with etcd
 
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -172,6 +172,19 @@ This example will create a dropin for the `etcd-member` systemd unit, configurin
 
 This is referencing dynamic data that isn't known until an instance is booted, for more information on how this works please take a look at the [referencing dynamic data][4] document.
 
+## Updates and Locksmithd
+
+```yaml
+update:
+  group:  "beta"
+locksmith:
+  reboot_strategy: "etcd-lock"
+  window_start:    "Sun 1:00"
+  window_length:   "2h"
+```
+
+This example configures the Container Linux instance to be a member of the beta group, configures locksmithd to acquire a lock in etcd before rebooting for an update, and only allows reboots during a 2 hour window starting at 1 AM on Sundays.
+
 [1]: configuration.md
 [2]: https://coreos.com/os/docs/latest/using-systemd-drop-in-units.html
 [3]: https://coreos.com/os/docs/latest/network-config-with-networkd.html


### PR DESCRIPTION
This commit allows users to configure all fields available in locksmithd, including things like reboot windows and etcd endpoints.

Fixes https://github.com/coreos/bugs/issues/1884.