### PR TITLE
config/types/flannel: added network-config option

### DIFF
--- a/config/types/etcd.go
+++ b/config/types/etcd.go
@@ -139,7 +139,12 @@ func etcdContents(etcd Etcd, platform string) (string, error) {
 		vars = []string{fmt.Sprintf("ETCD_IMAGE_TAG=v%s", etcd.Version)}
 	}
 
-	return assembleUnit("/usr/lib/coreos/etcd-wrapper $ETCD_OPTS", args, vars, platform)
+	unit, err := assembleUnit("/usr/lib/coreos/etcd-wrapper $ETCD_OPTS", args, vars, platform)
+	if err != nil {
+		return "", err
+	}
+
+	return unit.String(), nil
 }
 
 type Etcd3_0 struct {

--- a/config/types/flannel.go
+++ b/config/types/flannel.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -10,20 +11,37 @@ import (
 )
 
 var (
-	ErrFlannelTooOld      = errors.New("invalid flannel version (too old)")
-	ErrFlannelMinorTooNew = errors.New("flannel minor version too new. Only options available in the previous minor version will be supported")
-	OldestFlannelVersion  = *semver.New("0.5.0")
-	FlannelDefaultVersion = *semver.New("0.6.0")
+	ErrFlannelTooOld                  = errors.New("invalid flannel version (too old)")
+	ErrFlannelMinorTooNew             = errors.New("flannel minor version too new. Only options available in the previous minor version will be supported")
+	ErrNetConfigInvalidJSON           = errors.New("flannel network config doesn't appear to be valid JSON")
+	ErrNetConfigProvidedAndKubeMgrSet = errors.New("flannel network config cannot be provided if kube_subnet_mgr is set")
+	OldestFlannelVersion              = *semver.New("0.5.0")
+	FlannelDefaultVersion             = *semver.New("0.6.0")
 )
 
 type Flannel struct {
-	Version *FlannelVersion `yaml:"version"`
+	Version       *FlannelVersion `yaml:"version"`
+	NetworkConfig NetworkConfig   `yaml:"network_config"`
 	Options
 }
 
 type flannelCommon Flannel
 
 type FlannelVersion semver.Version
+
+type NetworkConfig string
+
+func (nc NetworkConfig) Validate() report.Report {
+	if nc == "" {
+		return report.Report{}
+	}
+	tmp := make(map[string]interface{})
+	err := json.Unmarshal([]byte(nc), &tmp)
+	if err != nil {
+		return report.ReportFromError(ErrNetConfigInvalidJSON, report.EntryError)
+	}
+	return report.Report{}
+}
 
 func (v *FlannelVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	t := semver.Version(*v)
@@ -47,6 +65,16 @@ func (fv FlannelVersion) Validate() report.Report {
 
 func (fv FlannelVersion) String() string {
 	return semver.Version(fv).String()
+}
+
+func (f *Flannel) Validate() report.Report {
+	switch o := f.Options.(type) {
+	case Flannel0_7:
+		if o.KubeSubnetMgr && f.NetworkConfig != "" {
+			return report.ReportFromError(ErrNetConfigProvidedAndKubeMgrSet, report.EntryError)
+		}
+	}
+	return report.Report{}
 }
 
 func (flannel *Flannel) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -113,6 +141,45 @@ func flannelContents(flannel Flannel, platform string) (string, error) {
 	unit, err := assembleUnit("/usr/lib/coreos/flannel-wrapper $FLANNEL_OPTS", args, vars, platform)
 	if err != nil {
 		return "", err
+	}
+
+	if flannel.NetworkConfig != "" {
+		pre := "ExecStartPre=/usr/bin/etcdctl"
+		var endpoints string
+		var etcdCAFile string
+		var etcdCertFile string
+		var etcdKeyFile string
+		switch o := flannel.Options.(type) {
+		case Flannel0_7:
+			endpoints = o.EtcdEndpoints
+			etcdCAFile = o.EtcdCAFile
+			etcdCertFile = o.EtcdCertFile
+			etcdKeyFile = o.EtcdKeyFile
+		case Flannel0_6:
+			endpoints = o.EtcdEndpoints
+			etcdCAFile = o.EtcdCAFile
+			etcdCertFile = o.EtcdCertFile
+			etcdKeyFile = o.EtcdKeyFile
+		case Flannel0_5:
+			endpoints = o.EtcdEndpoints
+			etcdCAFile = o.EtcdCAFile
+			etcdCertFile = o.EtcdCertFile
+			etcdKeyFile = o.EtcdKeyFile
+		}
+		if endpoints != "" {
+			pre += fmt.Sprintf(" --endpoints=%q", endpoints)
+		}
+		if etcdCAFile != "" {
+			pre += fmt.Sprintf(" --ca-file=%q", etcdCAFile)
+		}
+		if etcdCertFile != "" {
+			pre += fmt.Sprintf(" --cert-file=%q", etcdCertFile)
+		}
+		if etcdKeyFile != "" {
+			pre += fmt.Sprintf(" --key-file=%q", etcdKeyFile)
+		}
+		pre += fmt.Sprintf(" set /coreos.com/network/config %q", flannel.NetworkConfig)
+		unit.Service.Add(pre)
 	}
 
 	return unit.String(), nil

--- a/config/types/flannel.go
+++ b/config/types/flannel.go
@@ -110,7 +110,12 @@ func flannelContents(flannel Flannel, platform string) (string, error) {
 	args := getCliArgs(flannel.Options)
 	vars := []string{fmt.Sprintf("FLANNEL_IMAGE_TAG=v%s", flannel.Version)}
 
-	return assembleUnit("/usr/lib/coreos/flannel-wrapper $FLANNEL_OPTS", args, vars, platform)
+	unit, err := assembleUnit("/usr/lib/coreos/flannel-wrapper $FLANNEL_OPTS", args, vars, platform)
+	if err != nil {
+		return "", err
+	}
+
+	return unit.String(), nil
 }
 
 // Flannel0_7 represents flannel options for version 0.7.x. Don't embed Flannel0_6 because

--- a/config/types/util/unit.go
+++ b/config/types/util/unit.go
@@ -1,0 +1,62 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+type SystemdUnit struct {
+	Unit    *UnitSection
+	Service *UnitSection
+	Install *UnitSection
+}
+
+func NewSystemdUnit() SystemdUnit {
+	return SystemdUnit{
+		Unit:    &UnitSection{},
+		Service: &UnitSection{},
+		Install: &UnitSection{},
+	}
+}
+
+type UnitSection []string
+
+func (u *UnitSection) Add(line string) {
+	*u = append(*u, line)
+}
+
+func (s SystemdUnit) String() string {
+	res := ""
+
+	type section struct {
+		name     string
+		contents []string
+	}
+
+	for _, sec := range []section{
+		{"Unit", *s.Unit},
+		{"Service", *s.Service},
+		{"Install", *s.Install},
+	} {
+		if len(sec.contents) == 0 {
+			continue
+		}
+		if res != "" {
+			res += "\n\n"
+		}
+		res += "[" + sec.name + "]"
+		for _, line := range sec.contents {
+			res += "\n" + line
+		}
+	}
+	return res
+}

--- a/config/types/util/unit_test.go
+++ b/config/types/util/unit_test.go
@@ -1,0 +1,141 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+)
+
+type intype struct {
+	unit    []string
+	service []string
+	install []string
+}
+
+func TestBuildUnit(t *testing.T) {
+	tests := []struct {
+		in  intype
+		out string
+	}{
+		{
+			in: intype{
+				unit:    []string{},
+				service: []string{},
+				install: []string{},
+			},
+			out: "",
+		},
+		{
+			in: intype{
+				unit: []string{
+					"Description=etcd (System Application Container)",
+				},
+				service: []string{},
+				install: []string{},
+			},
+			out: `[Unit]
+Description=etcd (System Application Container)`,
+		},
+		{
+			in: intype{
+				unit: []string{
+					"Description=etcd (System Application Container)",
+					"Documentation=https://github.com/coreos/etcd",
+				},
+				service: []string{},
+				install: []string{},
+			},
+			out: `[Unit]
+Description=etcd (System Application Container)
+Documentation=https://github.com/coreos/etcd`,
+		},
+		{
+			in: intype{
+				unit: []string{
+					"Description=etcd (System Application Container)",
+					"Documentation=https://github.com/coreos/etcd",
+				},
+				service: []string{
+					"Environment=\"ETCD_IMAGE_TAG=v3.0.10\"",
+				},
+				install: []string{},
+			},
+			out: `[Unit]
+Description=etcd (System Application Container)
+Documentation=https://github.com/coreos/etcd
+
+[Service]
+Environment="ETCD_IMAGE_TAG=v3.0.10"`,
+		},
+		{
+			in: intype{
+				unit: []string{
+					"Description=etcd (System Application Container)",
+					"Documentation=https://github.com/coreos/etcd",
+				},
+				service: []string{},
+				install: []string{
+					"WantedBy=multi-user.target",
+				},
+			},
+			out: `[Unit]
+Description=etcd (System Application Container)
+Documentation=https://github.com/coreos/etcd
+
+[Install]
+WantedBy=multi-user.target`,
+		},
+		{
+			in: intype{
+				unit: []string{
+					"Description=etcd (System Application Container)",
+					"Documentation=https://github.com/coreos/etcd",
+				},
+				service: []string{
+					"Environment=\"ETCD_IMAGE_TAG=v3.0.10\"",
+				},
+				install: []string{
+					"WantedBy=multi-user.target",
+				},
+			},
+			out: `[Unit]
+Description=etcd (System Application Container)
+Documentation=https://github.com/coreos/etcd
+
+[Service]
+Environment="ETCD_IMAGE_TAG=v3.0.10"
+
+[Install]
+WantedBy=multi-user.target`,
+		},
+	}
+
+	for i, test := range tests {
+		unit := NewSystemdUnit()
+		for _, l := range test.in.unit {
+			unit.Unit.Add(l)
+		}
+		for _, l := range test.in.service {
+			unit.Service.Add(l)
+		}
+		for _, l := range test.in.install {
+			unit.Install.Add(l)
+		}
+		res := unit.String()
+		if res != test.out {
+			t.Errorf("#%d: result didn't match expected output.\nResult:\n%s\n\nExpected:\n%s", i, res, test.out)
+		}
+	}
+}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -96,6 +96,7 @@ _Note: all fields are optional unless otherwise marked_
   * **_other options_** (string): this section accepts any valid etcd options for the version of etcd specified. For a comprehensive list, please consult etcd's documentation. Note all options here should be in snake_case, not spine-case.
 * **flannel**
   * **version** (string): the version of flannel to be run
+  * **flannel_config** (string): the flannel configuration to be written into etcd before flannel starts.
   * **_other options_** (string): this section accepts any valid flannel options for the version of flannel specified. For a comprehensive list, please consult flannel's documentation. Note all options here should be in snake_case, not spine-case.
 * **docker**
   * **flags** (list of strings): additional flags to pass to the docker daemon when it is started


### PR DESCRIPTION
This commit adds a new field to flannel called network-config. When
contents are provided to it, an `ExecStartPre` is added to the produced
flannel unit that will call `etcdctl` to set flannel's config to the
endpoint that flannel is configured to use.

As an example the following config:

```yaml
flannel:
    version: 0.7.0
    network_config: |-
        { "Network": "10.1.0.0/16" }
    interface: "{PUBLIC_IPV4}"
    etcd_endpoints: "https://127.0.0.1:2379"
    etcd_cafile: "/etc/ssl/etcd/ca.pem"
    etcd_certfile: "/etc/ssl/etcd/cert.pem"
    etcd_keyfile: "/etc/ssl/etcd/key.pem"
```

Generates this unit:
```
[Unit]
Requires=coreos-metadata.service
After=coreos-metadata.service

[Service]
EnvironmentFile=/run/metadata/coreos
Environment="FLANNEL_IMAGE_TAG=v0.7.0"
ExecStart=
ExecStart=/usr/lib/coreos/flannel-wrapper $FLANNEL_OPTS \
  --etcd-endpoints="https://127.0.0.1:2379" \
  --etcd-cafile="/etc/ssl/etcd/ca.pem" \
  --etcd-certfile="/etc/ssl/etcd/cert.pem" \
  --etcd-keyfile="/etc/ssl/etcd/key.pem" \
  --iface="${COREOS_GCE_IP_LOCAL_0}"
ExecStartPre=/usr/bin/etcdctl --endpoints="https://127.0.0.1:2379" --ca-file="/etc/ssl/etcd/ca.pem" --cert-file="/etc/ssl/etcd/cert.pem" --key-file="/etc/ssl/etcd/key.pem" set /coreos.com/network/config "{ \"Network\": \"10.1.0.0/16\" }"

```

Fixes https://github.com/coreos/bugs/issues/1888