### PR TITLE
config/types/locksmith: replace hyphen with underscore

### DIFF
--- a/config/types/locksmith.go
+++ b/config/types/locksmith.go
@@ -26,7 +26,7 @@ var (
 )
 
 type Locksmith struct {
-	RebootStrategy RebootStrategy `yaml:"reboot-strategy"`
+	RebootStrategy RebootStrategy `yaml:"reboot_strategy"`
 }
 
 type RebootStrategy string

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -143,7 +143,7 @@ update:
   group:  "alpha"
   server: "https://public.update.core-os.net/v1/update/"
 locksmith:
-  reboot-strategy: "etcd-lock"
+  reboot_strategy: "etcd-lock"
 ```
 
 _Note: all fields are optional unless otherwise marked_
@@ -247,7 +247,7 @@ _Note: all fields are optional unless otherwise marked_
   * **group** (string): the update group to follow. Most users will want one of: stable, beta, alpha.
   * **server** (string): the server to fetch updates from.
 * **locksmith**
-  * **reboot-strategy** (string): the reboot strategy for locksmithd to follow. Must be one of: reboot, etcd-lock, off.
+  * **reboot_strategy** (string): the reboot strategy for locksmithd to follow. Must be one of: reboot, etcd-lock, off.
 
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397


### PR DESCRIPTION
This entire project uses underscores in yaml key names, the recent
locksmith commit broke this pattern by using a hyphen. This commit fixes
the mistake.