### PR TITLE
main: only print reports if there are entries

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -95,14 +95,18 @@ func main() {
 	}
 
 	cfg, report := config.Parse(dataIn)
-	stderr(report.String())
+	if len(report.Entries) > 0 {
+		stderr(report.String())
+	}
 	if report.IsFatal() || (flags.strict && len(report.Entries) > 0) {
 		stderr("Failed to parse config")
 		os.Exit(1)
 	}
 
 	ignCfg, report := config.ConvertAs2_0(cfg, flags.platform)
-	stderr(report.String())
+	if len(report.Entries) > 0 {
+		stderr(report.String())
+	}
 	if report.IsFatal() {
 		stderr("Generated Ignition config was invalid.")
 		os.Exit(1)


### PR DESCRIPTION
Without this change, two newlines are emitted on stderr, which offsets
the output of ct when run in a terminal.