### PR TITLE
config/types/{etcd,flannel}: make version field not required

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -496,11 +496,12 @@ etcd:
 `},
 			out: out{cfg: types.Config{
 				Etcd: &types.Etcd{
-					Version: types.EtcdVersion(semver.Version{
-						Major: 3,
-						Minor: 0,
-						Patch: 15,
-					}),
+					Version: func(t types.EtcdVersion) *types.EtcdVersion { return &t }(
+						types.EtcdVersion(semver.Version{
+							Major: 3,
+							Minor: 0,
+							Patch: 15,
+						})),
 					Options: types.Etcd3_0{
 						Discovery:        "https://discovery.etcd.io/<token>",
 						ListenClientUrls: "http://0.0.0.0:2379,http://0.0.0.0:4001",
@@ -517,11 +518,12 @@ flannel:
 `},
 			out: out{cfg: types.Config{
 				Flannel: &types.Flannel{
-					Version: types.FlannelVersion(semver.Version{
-						Major: 0,
-						Minor: 6,
-						Patch: 2,
-					}),
+					Version: func(t types.FlannelVersion) *types.FlannelVersion { return &t }(
+						types.FlannelVersion(semver.Version{
+							Major: 0,
+							Minor: 6,
+							Patch: 2,
+						})),
 					Options: types.Flannel0_6{
 						EtcdPrefix: "/coreos.com/network2",
 					},

--- a/config/types/flannel.go
+++ b/config/types/flannel.go
@@ -13,10 +13,11 @@ var (
 	ErrFlannelTooOld      = errors.New("invalid flannel version (too old)")
 	ErrFlannelMinorTooNew = errors.New("flannel minor version too new. Only options available in the previous minor version will be supported")
 	OldestFlannelVersion  = *semver.New("0.5.0")
+	FlannelDefaultVersion = *semver.New("0.6.0")
 )
 
 type Flannel struct {
-	Version FlannelVersion `yaml:"version"`
+	Version *FlannelVersion `yaml:"version"`
 	Options
 }
 
@@ -55,7 +56,13 @@ func (flannel *Flannel) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	*flannel = Flannel(t)
 
-	v := semver.Version(flannel.Version)
+	var v semver.Version
+	if flannel.Version == nil {
+		v = FlannelDefaultVersion
+	} else {
+		v = semver.Version(*flannel.Version)
+	}
+
 	if v.Major == 0 && v.Minor >= 7 {
 		o := Flannel0_7{}
 		if err := unmarshal(&o); err != nil {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -236,10 +236,10 @@ _Note: all fields are optional unless otherwise marked_
     * **gid** (integer): the group ID of the new group.
     * **password_hash** (string): the encrypted password of the new group.
 * **etcd**
-  * **version** (string, required): the version of etcd to be run
+  * **version** (string): the version of etcd to be run
   * **_other options_** (string): this section accepts any valid etcd options for the version of etcd specified. For a comprehensive list, please consult etcd's documentation. Note all options here should be in snake_case, not spine-case.
 * **flannel**
-  * **version** (string, required): the version of flannel to be run
+  * **version** (string): the version of flannel to be run
   * **_other options_** (string): this section accepts any valid flannel options for the version of flannel specified. For a comprehensive list, please consult flannel's documentation. Note all options here should be in snake_case, not spine-case.
 * **docker**
   * **flags** (list of strings): additional flags to pass to the docker daemon when it is started


### PR DESCRIPTION
This commit makes the version field in the etcd and flannel sections not
required. If the field is left empty, default versions are assumed
for the purposes of parsing and validating the passed options. For etcd,
v3.0 is assumed and for flannel, v0.6 is assumed.

Fixes https://github.com/coreos/bugs/issues/1894