### PR TITLE
internal: remove "generated ignition config is invalid" line

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -106,10 +106,9 @@ func main() {
 	ignCfg, report := config.ConvertAs2_0(cfg, flags.platform)
 	if len(report.Entries) > 0 {
 		stderr(report.String())
-	}
-	if report.IsFatal() {
-		stderr("Generated Ignition config was invalid.")
-		os.Exit(1)
+		if report.IsFatal() {
+			os.Exit(1)
+		}
 	}
 
 	var dataOut []byte


### PR DESCRIPTION
If conversion fails, the report is printed and the program is exited.
Before this commit the string "Generated Ignition config was invalid."
was printed to stderr, which is unnecessary since the report was already
printed.