### PR TITLE
Add Makefile to build static bin/ct binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+export CGO_ENABLED:=0
+
+VERSION=$(shell git describe --dirty)
+LD_FLAGS="-w -X github.com/coreos/container-linux-config-transpiler/version.Raw=$(VERSION)"
+
+REPO=github.com/coreos/container-linux-config-transpiler
+
+all: build
+
+build: bin/ct
+
+bin/ct:
+	@go build -o $@ -v -ldflags $(LD_FLAGS) $(REPO)/internal
+
+test:
+	@./test
+
+clean:
+	@rm -rf bin
+
+.PHONY: all build clean test

--- a/test
+++ b/test
@@ -29,6 +29,6 @@ echo "Checking govet..."
 go vet $PKG_VET
 
 echo "Running tests..."
-go test -timeout 60s -cover $@ ${PKG} --race
+go test -timeout 60s -cover $@ ${PKG}
 
 echo "Success"


### PR DESCRIPTION
`ct` release binaries are dynamically linked and don't work in various containers (e.g. scratch, alpine). Let's define a Makefile to formalize the build process so its not as dependent on whatever env vars the release engineer happens to have set. Notably, set CGO_ENABLED to 0.

I've left the old atypical build script which does symlinking, pending comment.