### PR TITLE
travis.yml: Add test coverage for Go 1.7 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: go
-matrix:
-  include:
-    - go: 1.5
-      env: GO15VENDOREXPERIMENT=1
-    - go: 1.6
-
+go:
+  - 1.7
+  - 1.8
 install:
   -
-
 script:
   - ./test


### PR DESCRIPTION
I think we mean to be supporting and testing against recent Go versions. Leave Go 1.5 or drop?