### PR TITLE
config/types: use %q for 'string' values

### DIFF
--- a/config/types/common.go
+++ b/config/types/common.go
@@ -97,6 +97,10 @@ func getArgs(format, tagName string, e interface{}) []string {
 				vars = append(vars, getCliArgs(val)...)
 			} else {
 				key := et.Field(i).Tag.Get(tagName)
+				if _, ok := val.(string); ok {
+					// to handle whitespace characters
+					val = fmt.Sprintf("%q", val)
+				}
 				vars = append(vars, fmt.Sprintf(format, key, val))
 			}
 		}
@@ -107,5 +111,5 @@ func getArgs(format, tagName string, e interface{}) []string {
 
 // getCliArgs builds a list of --ARG=VAL from a struct with cli: tags on its members.
 func getCliArgs(e interface{}) []string {
-	return getArgs("--%s=%q", "cli", e)
+	return getArgs("--%s=%v", "cli", e)
 }


### PR DESCRIPTION
boolean, integer values are broken in %q

We are getting

```
key, val: auto-compaction-retention '\x01'
key, val: debug %!q(bool=true)
```

since the default format string `"--%s=%q"`.

If there's any better way to handle this, please feel free to close this :)

Thanks!