### PR TITLE
config/templating: swap v4 public and private variables for gce

### DIFF
--- a/config/templating/templating.go
+++ b/config/templating/templating.go
@@ -71,8 +71,8 @@ var platformTemplatingMap = map[string]map[string]string{
 	},
 	PlatformGCE: {
 		fieldHostname:  "COREOS_GCE_HOSTNAME",
-		fieldV4Private: "COREOS_GCE_IP_EXTERNAL_0",
-		fieldV4Public:  "COREOS_GCE_IP_LOCAL_0",
+		fieldV4Private: "COREOS_GCE_IP_LOCAL_0",
+		fieldV4Public:  "COREOS_GCE_IP_EXTERNAL_0",
 	},
 	PlatformPacket: {
 		fieldHostname:  "COREOS_PACKET_HOSTNAME",


### PR DESCRIPTION
In the gce provider the public and private variable names were
backwards. This commit fixes that.