### PR TITLE
Makefile: Add release target to produce static binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 gopath/
 *.swp
+_output/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export CGO_ENABLED:=0
 
-VERSION=$(shell git describe --dirty)
+VERSION=$(shell ./git-version)
 LD_FLAGS="-w -X github.com/coreos/container-linux-config-transpiler/version.Raw=$(VERSION)"
 
 REPO=github.com/coreos/container-linux-config-transpiler
@@ -22,5 +22,20 @@ vendor:
 
 clean:
 	@rm -rf bin
+	@rm -rf _output
+
+.PHONY: release
+release: \
+	_output/unknown-linux-gnu/ct \
+	_output/apple-darwin/ct \
+	_output/pc-windows-gnu/ct
+
+_output/unknown-linux-gnu/ct: GOARGS = GOOS=linux GOARCH=amd64
+_output/apple-darwin/ct: GOARGS = GOOS=darwin GOARCH=amd64
+_output/pc-windows-gnu/ct: GOARGS = GOOS=windows GOARCH=amd64
+
+_output/%/ct: NAME=_output/ct-$(VERSION)-x86_64-$*
+_output/%/ct:
+	$(GOARGS) go build -o $(NAME) -ldflags $(LD_FLAGS) $(REPO)/internal
 
 .PHONY: all build clean test

--- a/git-version
+++ b/git-version
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+# parse the current git commit hash
+COMMIT=`git rev-parse HEAD`
+
+# check if the current commit has a matching tag
+TAG=$(git describe --exact-match --abbrev=0 --tags ${COMMIT} 2> /dev/null || true)
+
+# use the matching tag as the version, if available
+if [ -z "$TAG" ]; then
+    VERSION=$COMMIT
+else
+    VERSION=$TAG
+fi
+
+# check for changed files (not untracked files)
+if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
+    VERSION="${VERSION}-dirty"
+fi
+
+echo $VERSION
+


### PR DESCRIPTION
I noticed the v0.3.1 release is still dynamically linked and was build with the build script. Could we formalize the Makefile build/release?

Run `make release` at a release tag (say v0.3.2) to produce:

```
ls _output
ct-v0.3.2-x86_64-apple-darwin 
ct-v0.3.2-x86_64-pc-windows-gnu
ct-v0.3.2-x86_64-unknown-linux-gnu
```

I've matched the existing names (unknown-linux-gnu, apple-darwin, pc-windows-gnu), though they seem odd. Is there a reason for those? Maybe just linux, darwin, windows? cc @crawford 