### PR TITLE
main: expand strict coverage

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -106,7 +106,7 @@ func main() {
 	ignCfg, report := config.ConvertAs2_0(cfg, flags.platform)
 	if len(report.Entries) > 0 {
 		stderr(report.String())
-		if report.IsFatal() {
+		if report.IsFatal() || flags.strict {
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
When the strict flag was originally introduced, it didn't take into
account the fact that the conversion function can return non-fatal
reports. This corrects that mistake by failing when there are any
reports that are returned.