### PR TITLE
Update Readme.md for latest version to build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To build from source you'll need to have the go compiler installed on your syste
 ```shell
 git clone --branch v0.3.1 https://github.com/coreos/container-linux-config-transpiler
 cd container-linux-config-transpiler
-./build
+make build
 ```
 
 The `ct` binary will be placed in `./bin/`.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ The easiest way to get started using ct is to download one of the binaries from 
 To build from source you'll need to have the go compiler installed on your system.
 
 ```shell
-git clone --branch v0.1.0 https://github.com/coreos/container-linux-config-transpiler
+git clone --branch v0.3.1 https://github.com/coreos/container-linux-config-transpiler
 cd container-linux-config-transpiler
 ./build
 ```
 
 The `ct` binary will be placed in `./bin/`.
+
+Note: Review releases for new branch versions.
 
 ## Related projects
 


### PR DESCRIPTION
README.md: updated version number in --branch to most recent under compile from source

I compiled ct from source following the instructions in README.md and had issues with transpiling my config.  I opened an issue and after some research identified that I had pulled branch v0.1.0 instead of the most recent one.  To prevent other people from making this same mistake and to close out the issue I opened, I created this pull request with updated version and a note for current releases.  

Issue:  https://github.com/coreos/bugs/issues/1991


