### PR TITLE
Fixed a little typo and wrong types.

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -25,9 +25,9 @@ _Note: all fields are optional unless otherwise marked_
     * **partitions** (list of objects): the list of partitions and their configuration for this particular disk.
       * **label** (string): the PARTLABEL for the partition.
       * **number** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
-      * **size** (integer): the size of the partition. If zero, the partition will fill the remainder of the disk.
-      * **start** (integer): the start of the partition. If zero, the partition will be positioned at the earliest available part of the disk.
-      * **typeguid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
+      * **size** (string or integer): the size of the partition (e.g. 5GB). If zero, the partition will fill the remainder of the disk.
+      * **start** (string or integer): the start of the partition (e.g. 10GB). If zero, the partition will be positioned at the earliest available part of the disk.
+      * **type_guid** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
   * **raid** (list of objects): the list of RAID arrays to be configured.
     * **name** (string, required): the name to use for the resulting md device.
     * **level** (string, required): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).


### PR DESCRIPTION
Typo: `typeguid_` -> `type_guid`
Types:
start and size of partition is either "0" (integer) or some SI-unit ( e.g. "512B", "4KB", or "512GiB"), see: https://github.com/alecthomas/units/blob/master/bytes.go.