### PR TITLE
config/types: override sshkeys's opts on openstack-metadata

### DIFF
--- a/config/types/common.go
+++ b/config/types/common.go
@@ -44,6 +44,13 @@ func init() {
 					Contents: fmt.Sprintf("[Service]\nEnvironment=COREOS_METADATA_OPT_PROVIDER=--provider=%s", platform),
 				}},
 			})
+			out.Systemd.Units = append(out.Systemd.Units, ignTypes.SystemdUnit{
+				Name: "coreos-metadata-sshkeys@.service",
+				DropIns: []ignTypes.SystemdUnitDropIn{{
+					Name:     "20-clct-provider-override.conf",
+					Contents: fmt.Sprintf("[Service]\nEnvironment=COREOS_METADATA_OPT_PROVIDER=--provider=%s", platform),
+				}},
+			})
 		}
 		return out, report.Report{}, ast
 	})


### PR DESCRIPTION
coreos-metadata-sshkey@.service's provider should be overridden on the
openstack-metadata platform. This commit makes that change.