### PR TITLE
templating: add vagrant-virtualbox provider

### DIFF
--- a/config/templating/templating.go
+++ b/config/templating/templating.go
@@ -31,6 +31,7 @@ const (
 	PlatformGCE               = "gce"
 	PlatformPacket            = "packet"
 	PlatformOpenStackMetadata = "openstack-metadata"
+	PlatformVagrantVirtualbox = "vagrant-virtualbox"
 )
 
 var Platforms = []string{
@@ -40,6 +41,7 @@ var Platforms = []string{
 	PlatformGCE,
 	PlatformPacket,
 	PlatformOpenStackMetadata,
+	PlatformVagrantVirtualbox,
 }
 
 const (
@@ -84,6 +86,10 @@ var platformTemplatingMap = map[string]map[string]string{
 		fieldHostname:  "COREOS_OPENSTACK_HOSTNAME",
 		fieldV4Private: "COREOS_OPENSTACK_IPV4_LOCAL",
 		fieldV4Public:  "COREOS_OPENSTACK_IPV4_PUBLIC",
+	},
+	PlatformVagrantVirtualbox: {
+		fieldHostname:  "COREOS_VAGRANT_VIRTUALBOX_HOSTNAME",
+		fieldV4Private: "COREOS_VAGRANT_VIRTUALBOX_PRIVATE_IPV4",
 	},
 }
 

--- a/doc/dynamic-data.md
+++ b/doc/dynamic-data.md
@@ -22,6 +22,7 @@ This is the information available in each provider.
 | GCE                | ✓          | ✓              | ✓             |                |               |
 | Packet             | ✓          | ✓              | ✓             |                | ✓             |
 | OpenStack-Metadata | ✓          | ✓              | ✓             |                |               |
+| Vagrant-Virtualbox | ✓          | ✓              |               |                |               |
 
 ## Behind the scenes
 


### PR DESCRIPTION
This adds support for the vagrant-virtualbox provider, added in coreos-metadata version 0.11.0