### PR TITLE
config/types/flannel: allow empty version field

### DIFF
--- a/config/types/flannel.go
+++ b/config/types/flannel.go
@@ -137,7 +137,10 @@ func init() {
 // flannelContents creates the string containing the systemd drop in for flannel
 func flannelContents(flannel Flannel, platform string) (string, error) {
 	args := getCliArgs(flannel.Options)
-	vars := []string{fmt.Sprintf("FLANNEL_IMAGE_TAG=v%s", flannel.Version)}
+	var vars []string
+	if flannel.Version != nil {
+		vars = []string{fmt.Sprintf("FLANNEL_IMAGE_TAG=v%s", flannel.Version)}
+	}
 
 	unit, err := assembleUnit("/usr/lib/coreos/flannel-wrapper $FLANNEL_OPTS", args, vars, platform)
 	if err != nil {


### PR DESCRIPTION
Previously, if the version was not specified, the version was
printed as v\u003cnil\u003e in the outputted ignition file.
This fixes that.