### PR TITLE
docs: Fix naming mismatch causing etcd failure.

### DIFF
--- a/doc/dynamic-data.md
+++ b/doc/dynamic-data.md
@@ -36,7 +36,7 @@ etcd:
   initial_advertise_peer_urls: "http://{PRIVATE_IPV4}:2380"
   listen_client_urls:          "http://0.0.0.0:2379"
   listen_peer_urls:            "http://{PRIVATE_IPV4}:2380"
-  initial_cluster:             "%m=http://{PRIVATE_IPV4}:2380"
+  initial_cluster:             "{HOSTNAME}=http://{PRIVATE_IPV4}:2380"
 ```
 
 If we give this example to ct with the `--platform=ec2` tag, it produces the following drop-in:
@@ -55,7 +55,7 @@ ExecStart=/usr/lib/coreos/etcd-wrapper $ETCD_OPTS \
   --listen-peer-urls="http://${COREOS_EC2_IPV4_LOCAL}:2380" \
   --listen-client-urls="http://0.0.0.0:2379" \
   --initial-advertise-peer-urls="http://${COREOS_EC2_IPV4_LOCAL}:2380" \
-  --initial-cluster="%m=http://${COREOS_EC2_IPV4_LOCAL}:2380" \
+  --initial-cluster="${COREOS_EC2_HOSTNAME}=http://${COREOS_EC2_IPV4_LOCAL}:2380" \
   --advertise-client-urls="http://${COREOS_EC2_IPV4_LOCAL}:2379"
 ```
 

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -165,7 +165,7 @@ etcd:
   initial_advertise_peer_urls: "http://{PRIVATE_IPV4}:2380"
   listen_client_urls:          "http://0.0.0.0:2379"
   listen_peer_urls:            "http://{PRIVATE_IPV4}:2380"
-  initial_cluster:             "%m=http://{PRIVATE_IPV4}:2380"
+  initial_cluster:             "{HOSTNAME}=http://{PRIVATE_IPV4}:2380"
 ```
 
 This example will create a dropin for the `etcd-member` systemd unit, configuring it to use the specified version and adding all the specified options. This will also enable the `etcd-member` unit.


### PR DESCRIPTION
This resolves an issue where the example provided causes etcd-member to fail the startup process.

```
Jul 18 15:47:56 core-01 etcd-wrapper[1027]: 2017-07-18 15:47:56.788293 C | etcdmain: couldn't find local name "$HOSTNAME" in the initial cluster configuration
```

Refs https://github.com/coreos/bugs/issues/2054

### Edits ###

- Tested on `vagrant-virtualbox`