### PR TITLE
Check platform

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ import (
 
 	yaml "github.com/ajeddeloh/yaml"
 	"github.com/coreos/container-linux-config-transpiler/config/astyaml"
+	"github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/container-linux-config-transpiler/config/types"
 	ignTypes "github.com/coreos/ignition/config/v2_0/types"
 	"github.com/coreos/ignition/config/validate"
@@ -66,6 +67,14 @@ func Parse(data []byte) (types.Config, validate.AstNode, report.Report) {
 // ConvertAs2_0 also accepts a platform string, which can either be one of the
 // platform strings defined in config/templating/templating.go or an empty
 // string if [dynamic data](doc/dynamic-data.md) isn't used.
-func ConvertAs2_0(in types.Config, platform string, ast validate.AstNode) (ignTypes.Config, report.Report) {
-	return types.ConvertAs2_0(in, platform, ast)
+func ConvertAs2_0(in types.Config, p string, ast validate.AstNode) (ignTypes.Config, report.Report) {
+	if !platform.IsSupportedPlatform(p) {
+		r := report.Report{}
+		r.Add(report.Entry{
+			Kind:    report.EntryError,
+			Message: "unsupported platform",
+		})
+		return ignTypes.Config{}, r
+	}
+	return types.ConvertAs2_0(in, p, ast)
 }

--- a/config/platform/platform.go
+++ b/config/platform/platform.go
@@ -1,0 +1,44 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+const (
+	Azure             = "azure"
+	DO                = "digitalocean"
+	EC2               = "ec2"
+	GCE               = "gce"
+	Packet            = "packet"
+	OpenStackMetadata = "openstack-metadata"
+	VagrantVirtualbox = "vagrant-virtualbox"
+)
+
+var Platforms = []string{
+	Azure,
+	DO,
+	EC2,
+	GCE,
+	Packet,
+	OpenStackMetadata,
+	VagrantVirtualbox,
+}
+
+func IsSupportedPlatform(platform string) bool {
+	for _, supportedPlatform := range Platforms {
+		if supportedPlatform == platform {
+			return true
+		}
+	}
+	return platform == ""
+}

--- a/config/templating/templating.go
+++ b/config/templating/templating.go
@@ -17,32 +17,14 @@ package templating
 import (
 	"fmt"
 	"strings"
+
+	"github.com/coreos/container-linux-config-transpiler/config/platform"
 )
 
 var (
 	ErrUnknownPlatform = fmt.Errorf("unsupported platform")
 	ErrUnknownField    = fmt.Errorf("unknown field")
 )
-
-const (
-	PlatformAzure             = "azure"
-	PlatformDO                = "digitalocean"
-	PlatformEC2               = "ec2"
-	PlatformGCE               = "gce"
-	PlatformPacket            = "packet"
-	PlatformOpenStackMetadata = "openstack-metadata"
-	PlatformVagrantVirtualbox = "vagrant-virtualbox"
-)
-
-var Platforms = []string{
-	PlatformAzure,
-	PlatformDO,
-	PlatformEC2,
-	PlatformGCE,
-	PlatformPacket,
-	PlatformOpenStackMetadata,
-	PlatformVagrantVirtualbox,
-}
 
 const (
 	fieldHostname  = "HOSTNAME"
@@ -53,12 +35,12 @@ const (
 )
 
 var platformTemplatingMap = map[string]map[string]string{
-	PlatformAzure: {
+	platform.Azure: {
 		// TODO: is this right?
 		fieldV4Private: "COREOS_AZURE_IPV4_DYNAMIC",
 		fieldV4Public:  "COREOS_AZURE_IPV4_VIRTUAL",
 	},
-	PlatformDO: {
+	platform.DO: {
 		// TODO: unused: COREOS_DIGITALOCEAN_IPV4_ANCHOR_0
 		fieldHostname:  "COREOS_DIGITALOCEAN_HOSTNAME",
 		fieldV4Private: "COREOS_DIGITALOCEAN_IPV4_PRIVATE_0",
@@ -66,28 +48,28 @@ var platformTemplatingMap = map[string]map[string]string{
 		fieldV6Private: "COREOS_DIGITALOCEAN_IPV6_PRIVATE_0",
 		fieldV6Public:  "COREOS_DIGITALOCEAN_IPV6_PUBLIC_0",
 	},
-	PlatformEC2: {
+	platform.EC2: {
 		fieldHostname:  "COREOS_EC2_HOSTNAME",
 		fieldV4Private: "COREOS_EC2_IPV4_LOCAL",
 		fieldV4Public:  "COREOS_EC2_IPV4_PUBLIC",
 	},
-	PlatformGCE: {
+	platform.GCE: {
 		fieldHostname:  "COREOS_GCE_HOSTNAME",
 		fieldV4Private: "COREOS_GCE_IP_LOCAL_0",
 		fieldV4Public:  "COREOS_GCE_IP_EXTERNAL_0",
 	},
-	PlatformPacket: {
+	platform.Packet: {
 		fieldHostname:  "COREOS_PACKET_HOSTNAME",
 		fieldV4Private: "COREOS_PACKET_IPV4_PRIVATE_0",
 		fieldV4Public:  "COREOS_PACKET_IPV4_PUBLIC_0",
 		fieldV6Public:  "COREOS_PACKET_IPV6_PUBLIC_0",
 	},
-	PlatformOpenStackMetadata: {
+	platform.OpenStackMetadata: {
 		fieldHostname:  "COREOS_OPENSTACK_HOSTNAME",
 		fieldV4Private: "COREOS_OPENSTACK_IPV4_LOCAL",
 		fieldV4Public:  "COREOS_OPENSTACK_IPV4_PUBLIC",
 	},
-	PlatformVagrantVirtualbox: {
+	platform.VagrantVirtualbox: {
 		fieldHostname:  "COREOS_VAGRANT_VIRTUALBOX_HOSTNAME",
 		fieldV4Private: "COREOS_VAGRANT_VIRTUALBOX_PRIVATE_IPV4",
 	},

--- a/internal/main.go
+++ b/internal/main.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/coreos/container-linux-config-transpiler/config"
-	"github.com/coreos/container-linux-config-transpiler/config/templating"
+	"github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/container-linux-config-transpiler/internal/version"
 )
 
@@ -49,7 +49,7 @@ func main() {
 	flag.StringVar(&flags.inFile, "in-file", "", "Path to the container linux config. Standard input unless specified otherwise.")
 	flag.StringVar(&flags.outFile, "out-file", "", "Path to the resulting Ignition config. Standard output unless specified otherwise.")
 	flag.BoolVar(&flags.strict, "strict", false, "Fail if any warnings are encountered.")
-	flag.StringVar(&flags.platform, "platform", "", fmt.Sprintf("Platform to target. Accepted values: %v.", templating.Platforms))
+	flag.StringVar(&flags.platform, "platform", "", fmt.Sprintf("Platform to target. Accepted values: %v.", platform.Platforms))
 
 	flag.Parse()
 


### PR DESCRIPTION
Before this PR ct only checked if the platform was valid when templating was used. While this probably should have been checked in every situation from the start, with the addition of [overriding coreos-metadata's platform when the openstack-metadata platform is used](https://github.com/coreos/container-linux-config-transpiler/commit/d273220f53c727aca507d254828460404f329eeb), there were now situations where the platform is relevant outside of templating.

Fixes https://github.com/coreos/bugs/issues/2075