### PR TITLE
config/types/passwd: always emit create for non-core users

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1056,6 +1056,7 @@ func TestConvertAs2_0(t *testing.T) {
 							Name:              "user 1",
 							PasswordHash:      "password 1",
 							SSHAuthorizedKeys: []string{"key1", "key2"},
+							Create:            &ignTypes.UserCreate{},
 						},
 						{
 							Name:              "user 2",

--- a/config/types/passwd.go
+++ b/config/types/passwd.go
@@ -55,6 +55,9 @@ type Group struct {
 func init() {
 	register2_0(func(in Config, ast validate.AstNode, out ignTypes.Config, platform string) (ignTypes.Config, report.Report, validate.AstNode) {
 		for _, user := range in.Passwd.Users {
+			if user.Name != "core" && user.Create == nil {
+				user.Create = &UserCreate{}
+			}
 			newUser := ignTypes.User{
 				Name:              user.Name,
 				PasswordHash:      user.PasswordHash,


### PR DESCRIPTION
Fixes https://github.com/coreos/bugs/issues/2003