### PR TITLE
glide.yaml: vendor ignition v0.17.2

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 108dfecb065ae7628c6eea011e78e9ae25fc029d8770d6784ad26ede77a90ba5
-updated: 2017-06-20T18:10:38.968919013-04:00
+hash: 866f7f8e6abd6c52e124db97d9c5665e261f65a06289e9803dfd18c6720ca40f
+updated: 2017-08-07T13:11:10.67669909-07:00
 imports:
 - name: github.com/ajeddeloh/yaml
   version: 1072abfea31191db507785e2e0c1b8d1440d35a5
@@ -15,7 +15,7 @@ imports:
   - dbus
   - unit
 - name: github.com/coreos/ignition
-  version: 94330dad80def6a1066037713b24ac6ac624985f
+  version: 11813c57bc05f30644bbae7891ae30a4a62e0b33
   subpackages:
   - config/types
   - config/v2_0/types

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/alecthomas/units
   version: 6b4e7dc5e3143b85ea77909c72caf89416fc2915
 - package: github.com/coreos/ignition
-  version: 94330dad80def6a1066037713b24ac6ac624985f
+  version: v0.17.2
   subpackages:
   - config/types
   - config/validate
@@ -14,4 +14,3 @@ import:
   version: 5e3acbb5668c4c3deb4842615c4098eb61fb6b1e
 - package: github.com/vincent-petithory/dataurl
   version: 9a301d65acbb728fcc3ace14f45f511a4cfeea9c
-

--- a/vendor/github.com/coreos/ignition/config/types/config.go
+++ b/vendor/github.com/coreos/ignition/config/types/config.go
@@ -25,7 +25,7 @@ import (
 var (
 	MaxVersion = semver.Version{
 		Major:      2,
-		Minor:      1,
+		Minor:      2,
 		PreRelease: "experimental",
 	}
 )

--- a/vendor/github.com/coreos/ignition/config/types/schema.go
+++ b/vendor/github.com/coreos/ignition/config/types/schema.go
@@ -66,8 +66,6 @@ type Filesystem struct {
 	Path  *string `json:"path,omitempty"`
 }
 
-type Group string
-
 type Ignition struct {
 	Config   IgnitionConfig `json:"config,omitempty"`
 	Timeouts Timeouts       `json:"timeouts,omitempty"`
@@ -151,7 +149,7 @@ type PasswdGroup struct {
 type PasswdUser struct {
 	Create            *Usercreate        `json:"create,omitempty"`
 	Gecos             string             `json:"gecos,omitempty"`
-	Groups            []Group            `json:"groups,omitempty"`
+	Groups            []PasswdUserGroup  `json:"groups,omitempty"`
 	HomeDir           string             `json:"homeDir,omitempty"`
 	Name              string             `json:"name,omitempty"`
 	NoCreateHome      bool               `json:"noCreateHome,omitempty"`
@@ -164,6 +162,8 @@ type PasswdUser struct {
 	System            bool               `json:"system,omitempty"`
 	UID               *int               `json:"uid,omitempty"`
 }
+
+type PasswdUserGroup string
 
 type Raid struct {
 	Devices []Device `json:"devices,omitempty"`
@@ -196,6 +196,7 @@ type Unit struct {
 	Contents string   `json:"contents,omitempty"`
 	Dropins  []Dropin `json:"dropins,omitempty"`
 	Enable   bool     `json:"enable,omitempty"`
+	Enabled  *bool    `json:"enabled,omitempty"`
 	Mask     bool     `json:"mask,omitempty"`
 	Name     string   `json:"name,omitempty"`
 }

--- a/vendor/github.com/coreos/ignition/config/types/url.go
+++ b/vendor/github.com/coreos/ignition/config/types/url.go
@@ -36,7 +36,7 @@ func validateURL(s string) error {
 	}
 
 	switch u.Scheme {
-	case "http", "https", "oem", "tftp":
+	case "http", "https", "oem", "tftp", "s3":
 		return nil
 	case "data":
 		if _, err := dataurl.DecodeString(s); err != nil {


### PR DESCRIPTION
We'd like to update ct within matchbox since it hasn't been updated in a while https://github.com/coreos/matchbox/issues/606. Using Ignition v0.17.2 seems like a good place to make the cut.