### PR TITLE
platforms: change vagrant-virtualbox to virtualbox

### DIFF
--- a/config/platform/platform.go
+++ b/config/platform/platform.go
@@ -21,7 +21,7 @@ const (
 	GCE               = "gce"
 	Packet            = "packet"
 	OpenStackMetadata = "openstack-metadata"
-	VagrantVirtualbox = "vagrant-virtualbox"
+	Virtualbox        = "virtualbox"
 )
 
 var Platforms = []string{
@@ -31,7 +31,7 @@ var Platforms = []string{
 	GCE,
 	Packet,
 	OpenStackMetadata,
-	VagrantVirtualbox,
+	Virtualbox,
 }
 
 func IsSupportedPlatform(platform string) bool {

--- a/config/templating/templating.go
+++ b/config/templating/templating.go
@@ -69,9 +69,9 @@ var platformTemplatingMap = map[string]map[string]string{
 		fieldV4Private: "COREOS_OPENSTACK_IPV4_LOCAL",
 		fieldV4Public:  "COREOS_OPENSTACK_IPV4_PUBLIC",
 	},
-	platform.VagrantVirtualbox: {
-		fieldHostname:  "COREOS_VAGRANT_VIRTUALBOX_HOSTNAME",
-		fieldV4Private: "COREOS_VAGRANT_VIRTUALBOX_PRIVATE_IPV4",
+	platform.Virtualbox: {
+		fieldHostname:  "COREOS_VIRTUALBOX_HOSTNAME",
+		fieldV4Private: "COREOS_VIRTUALBOX_IPV4_PRIVATE",
 	},
 }
 

--- a/doc/dynamic-data.md
+++ b/doc/dynamic-data.md
@@ -22,7 +22,7 @@ This is the information available in each provider.
 | GCE                | ✓          | ✓              | ✓             |                |               |
 | Packet             | ✓          | ✓              | ✓             |                | ✓             |
 | OpenStack-Metadata | ✓          | ✓              | ✓             |                |               |
-| Vagrant-Virtualbox | ✓          | ✓              |               |                |               |
+| Virtualbox         | ✓          | ✓              |               |                |               |
 
 ## Behind the scenes
 


### PR DESCRIPTION
As part of using generic oem-ids for vagrant provisioned VMS, we are
changing vagrant-virtualbox to virtualbox.