### PR TITLE
config/types/locksmith: don't use custom types to validate fields

### DIFF
--- a/config/types/locksmith.go
+++ b/config/types/locksmith.go
@@ -33,23 +33,19 @@ var (
 )
 
 type Locksmith struct {
-	RebootStrategy RebootStrategy `yaml:"reboot_strategy" locksmith:"REBOOT_STRATEGY"`
-	WindowStart    WindowStart    `yaml:"window_start"    locksmith:"LOCKSMITHD_REBOOT_WINDOW_START"`
-	WindowLength   WindowLength   `yaml:"window_length"   locksmith:"LOCKSMITHD_REBOOT_WINDOW_LENGTH"`
-	Group          string         `yaml:"group"           locksmith:"LOCKSMITHD_GROUP"`
-	EtcdEndpoints  string         `yaml:"etcd_endpoints"  locksmith:"LOCKSMITHD_ENDPOINT"`
-	EtcdCAFile     string         `yaml:"etcd_cafile"     locksmith:"LOCKSMITHD_ETCD_CAFILE"`
-	EtcdCertFile   string         `yaml:"etcd_certfile"   locksmith:"LOCKSMITHD_ETCD_CERTFILE"`
-	EtcdKeyFile    string         `yaml:"etcd_keyfile"    locksmith:"LOCKSMITHD_ETCD_KEYFILE"`
+	RebootStrategy string `yaml:"reboot_strategy" locksmith:"REBOOT_STRATEGY"`
+	WindowStart    string `yaml:"window_start"    locksmith:"LOCKSMITHD_REBOOT_WINDOW_START"`
+	WindowLength   string `yaml:"window_length"   locksmith:"LOCKSMITHD_REBOOT_WINDOW_LENGTH"`
+	Group          string `yaml:"group"           locksmith:"LOCKSMITHD_GROUP"`
+	EtcdEndpoints  string `yaml:"etcd_endpoints"  locksmith:"LOCKSMITHD_ENDPOINT"`
+	EtcdCAFile     string `yaml:"etcd_cafile"     locksmith:"LOCKSMITHD_ETCD_CAFILE"`
+	EtcdCertFile   string `yaml:"etcd_certfile"   locksmith:"LOCKSMITHD_ETCD_CERTFILE"`
+	EtcdKeyFile    string `yaml:"etcd_keyfile"    locksmith:"LOCKSMITHD_ETCD_KEYFILE"`
 }
 
 func (l Locksmith) configLines() []string {
-	return getArgs("%s=%q", "locksmith", l)
+	return getArgs("%s=%v", "locksmith", l)
 }
-
-type RebootStrategy string
-type WindowStart string
-type WindowLength string
 
 func (l Locksmith) Validate() report.Report {
 	if (l.WindowStart != "" && l.WindowLength == "") || (l.WindowStart == "" && l.WindowLength != "") {
@@ -58,8 +54,8 @@ func (l Locksmith) Validate() report.Report {
 	return report.Report{}
 }
 
-func (r RebootStrategy) Validate() report.Report {
-	switch strings.ToLower(string(r)) {
+func (l Locksmith) ValidateRebootStrategy() report.Report {
+	switch strings.ToLower(l.RebootStrategy) {
 	case "reboot", "etcd-lock", "off":
 		return report.Report{}
 	default:
@@ -67,17 +63,17 @@ func (r RebootStrategy) Validate() report.Report {
 	}
 }
 
-func (s WindowStart) Validate() report.Report {
-	if s == "" {
+func (l Locksmith) ValidateWindowStart() report.Report {
+	if l.WindowStart == "" {
 		return report.Report{}
 	}
 	var day string
 	var t string
 
-	_, err := fmt.Sscanf(string(s), "%s %s", &day, &t)
+	_, err := fmt.Sscanf(l.WindowStart, "%s %s", &day, &t)
 	if err != nil {
 		day = "not-present"
-		t = string(s)
+		t = l.WindowStart
 	}
 
 	switch strings.ToLower(day) {
@@ -95,11 +91,11 @@ func (s WindowStart) Validate() report.Report {
 	return report.Report{}
 }
 
-func (l WindowLength) Validate() report.Report {
-	if l == "" {
+func (l Locksmith) ValidateWindowLength() report.Report {
+	if l.WindowLength == "" {
 		return report.Report{}
 	}
-	_, err := time.ParseDuration(string(l))
+	_, err := time.ParseDuration(l.WindowLength)
 	if err != nil {
 		return report.ReportFromError(ErrParsingLength, report.EntryError)
 	}

--- a/config/types/locksmith_test.go
+++ b/config/types/locksmith_test.go
@@ -54,7 +54,7 @@ func TestValidateWindowStart(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		r := WindowStart(test.in.start).Validate()
+		r := Locksmith{WindowStart: test.in.start}.ValidateWindowStart()
 		if !reflect.DeepEqual(test.out.r, r) {
 			t.Errorf("#%d: wanted %v, got %v", i, test.out.r, r)
 		}


### PR DESCRIPTION
Change validation logic in the locksmith struct to attach all validation
functions to the top level locksmith struct, such that the string
special casing in config/types/common.go#getArgs can be relied on to
quote escape the strings, and %s can be used in the provided format
string instead of %q.

This bug was introduced in https://github.com/coreos/container-linux-config-transpiler/pull/66. It only affects the locksmith section because the format string the locksmith section provides to `getArgs` was `%q` to handle spaces before the PR that introduced the bug, and I believe that I didn't notice this bug when reviewing that PR because some of the fields in the `Locksmith` struct were type aliased so that validation functions could be attached, and thus failed the string special casing logic of `getArgs` that was added, and were formatted properly. Note that only some of the locksmith fields are double escaped.

Fixes https://github.com/coreos/bugs/issues/2155