### PR TITLE
docs: fix passwd.users wording to match 2.1.0 spec

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -105,7 +105,7 @@ _Note: all fields are optional unless otherwise marked_
     * **name** (string, required): the name of the file. This must be suffixed with a valid unit type (e.g. "00-eth0.network").
     * **contents** (string): the contents of the networkd file.
 * **passwd** (object): describes the desired additions to the passwd database.
-  * **users** (list of objects): the list of accounts to be added.
+  * **users** (list of objects): the list of accounts that shall exist.
     * **name** (string, required): the username for the account.
     * **password_hash** (string): the encrypted password for the account.
     * **ssh_authorized_keys** (list of strings): a list of SSH keys to be added to the user's authorized_keys.


### PR DESCRIPTION
Reword documentation of passwd.users to be declaritive not imperitive.

Fixes https://github.com/coreos/bugs/issues/1967

I left the `passwd.groups` alone because
1) Ignition's docs are written that way
2) Ignition's docs are correct. We do not do the checking we do with users and instead call `groupadd` with no checks for existing groups, thus it really is a list of "groups to create". This is probably not ideal (unless there's some explicit reason we do it this way), but we should fix the behavior before the docs.