### PR TITLE
config: enable coreos-metadata-sshkeys serice on openstack

### DIFF
--- a/config/types/common.go
+++ b/config/types/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/container-linux-config-transpiler/config/templating"
 	"github.com/coreos/container-linux-config-transpiler/config/types/util"
+	iutil "github.com/coreos/container-linux-config-transpiler/internal/util"
 	"github.com/coreos/ignition/config/validate/astnode"
 )
 
@@ -46,7 +47,8 @@ func init() {
 				}},
 			})
 			out.Systemd.Units = append(out.Systemd.Units, ignTypes.Unit{
-				Name: "coreos-metadata-sshkeys@.service",
+				Name:    "coreos-metadata-sshkeys@.service",
+				Enabled: iutil.BoolToPtr(true),
 				Dropins: []ignTypes.Dropin{{
 					Name:     "20-clct-provider-override.conf",
 					Contents: fmt.Sprintf("[Service]\nEnvironment=COREOS_METADATA_OPT_PROVIDER=--provider=%s", p),


### PR DESCRIPTION
when an openstack provider is specified to ct, a dropin is created to
override the provider value when coreos-metadata is run. this is because
there is no "openstack" provider, since there are two possible metadata
sources and we can't rely on either existing or discover which to use,
so it must be specified for us explicitly.

however, the dropin that was created failed to enable the ssh-keys
service. this would normally be done by ignition for providers where we
can retrieve ssh keys, but since openstack keys are only available if we
know which metadata service to use, we have to enable it in the dropin
instead of enabling it across the board for the openstack provider.

ref coreos/bugs#2247