### PR TITLE
doc: use /bin/bash in shell example

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -42,7 +42,7 @@ passwd:
       groups:
         - wheel
         - plugdev
-      shell: /bin/zsh
+      shell: /bin/bash
 ```
 
 This example creates one user, `user1`, with the password hash `$6$43y3tkl...`, and sets up one ssh public key for the user. The user is also given the home directory `/home/user1`, but it's not created, the user is added to the `wheel` and `plugdev` groups, and the user's shell is set to `/bin/zsh`.


### PR DESCRIPTION
the docs have an example that modifies the shell to /bin/zsh, but
container linux doesn't have /bin/zsh installed, and probably never
will. this updates the example to work on actual machines.

fixes coreos/bugs#2274