### PR TITLE
readme: fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To build from source you'll need to have the go compiler installed on your syste
 ```shell
 git clone --branch v0.3.1 https://github.com/coreos/container-linux-config-transpiler
 cd container-linux-config-transpiler
-make build
+make
 ```
 
 The `ct` binary will be placed in `./bin/`.


### PR DESCRIPTION
There is no "build" target, but just `make` does produce a binary.