### PR TITLE
Actually report remote url errors in remote file config

### DIFF
--- a/config/types/files.go
+++ b/config/types/files.go
@@ -114,6 +114,7 @@ func init() {
 						line, col, _ := n.ValueLineCol(nil)
 						convertReport.AddPosition(line, col, "")
 					}
+					r.Merge(convertReport)
 					continue
 				}
 


### PR DESCRIPTION
The report was created, but never merged, so it would not be presented to the user in the case of an error.