### PR TITLE
Add support for local files

### DIFF
--- a/config/types/files.go
+++ b/config/types/files.go
@@ -15,8 +15,11 @@
 package types
 
 import (
+	"errors"
+	"flag"
 	"io/ioutil"
 	"net/url"
+	"path"
 
 	"github.com/coreos/container-linux-config-transpiler/config/astyaml"
 
@@ -108,7 +111,21 @@ func init() {
 			}
 
 			if file.Contents.Local != "" {
-				contents, err := ioutil.ReadFile(file.Contents.Local)
+				// The provided local file path is relative to the value of the
+				// --files-dir flag.
+				filesDir := flag.Lookup("files-dir")
+				if filesDir == nil || filesDir.Value.String() == "" {
+					err := errors.New("local files require setting the --files-dir flag to the directory that contains the file")
+					flagReport := report.ReportFromError(err, report.EntryError)
+					if n, err := getNodeChildPath(file_node, "contents", "local"); err == nil {
+						line, col, _ := n.ValueLineCol(nil)
+						flagReport.AddPosition(line, col, "")
+					}
+					r.Merge(flagReport)
+					continue
+				}
+				localPath := path.Join(filesDir.Value.String(), file.Contents.Local)
+				contents, err := ioutil.ReadFile(localPath)
 				if err != nil {
 					// If the file could not be read, record error and continue.
 					convertReport := report.ReportFromError(err, report.EntryError)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -55,7 +55,8 @@ _Note: all fields are optional unless otherwise marked_
     * **path** (string, required): the absolute path to the file.
     * **contents** (object): options related to the contents of the file.
       * **inline** (string): the contents of the file.
-      * **remote** (object): options related to the fetching of remote file contents.
+      * **local** (string): the path to a local file, relative to the `--files-dir` directory. When using local files, the `--files-dir` flag must be passed to `ct`. The file contents are included in the generated config.
+      * **remote** (object): options related to the fetching of remote file contents. Remote files are fetched by Ignition when Ignition runs, the contents are not included in the generated config.
         * **compression** (string): the type of compression used on the contents (null or gzip)
         * **url** (string): the URL of the file contents. Supported schemes are http, https, tftp, s3, and [data][rfc2397]. Note: When using http, it is advisable to use the verification option to ensure the contents haven't been modified.
         * **verification** (object): options related to the verification of the file contents.

--- a/internal/main.go
+++ b/internal/main.go
@@ -41,6 +41,7 @@ func main() {
 		outFile  string
 		strict   bool
 		platform string
+		filesDir string
 	}{}
 
 	flag.BoolVar(&flags.help, "help", false, "Print help and exit.")
@@ -50,6 +51,7 @@ func main() {
 	flag.StringVar(&flags.outFile, "out-file", "", "Path to the resulting Ignition config. Standard output unless specified otherwise.")
 	flag.BoolVar(&flags.strict, "strict", false, "Fail if any warnings are encountered.")
 	flag.StringVar(&flags.platform, "platform", "", fmt.Sprintf("Platform to target. Accepted values: %v.", platform.Platforms))
+	flag.StringVar(&flags.filesDir, "files-dir", "", "Directory to read local files from.")
 
 	flag.Parse()
 


### PR DESCRIPTION
This adds one more file contents source, `local`, in addition to `inline` and `remote`. It takes a filename, and includes the contents of that file. This is useful when you don’t want to pollute the ign file with many large inline files, or when you don’t want to indent the contents of the file to fit the yaml syntax. Also, editing such a local config file is easier when it is a separate file, because an editor can enable format-specific features.

Local files are expected to be in the same directory as the ign file, so you could track both under source control; this is just for convenience.

Currently this uses the path as is, so local paths are interpreted relative to the working directory. It would be nice to have them relative to the ign file, so the output does not depend on where `ct` is invoked. However, this is not always possible (when the input is stdin), and I am not sure what the best way to thread the input filename through the program is, for the case where it is available. Feedback would be appreciated.