### PR TITLE
readme: update git clone --branch from v0.3.1 to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The easiest way to get started using ct is to download one of the binaries from 
 To build from source you'll need to have the go compiler installed on your system.
 
 ```shell
-git clone https://github.com/coreos/container-linux-config-transpiler
+git clone --branch v0.5.0 https://github.com/coreos/container-linux-config-transpiler
 cd container-linux-config-transpiler
 make
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The easiest way to get started using ct is to download one of the binaries from 
 To build from source you'll need to have the go compiler installed on your system.
 
 ```shell
-git clone --branch v0.3.1 https://github.com/coreos/container-linux-config-transpiler
+git clone https://github.com/coreos/container-linux-config-transpiler
 cd container-linux-config-transpiler
 make
 ```


### PR DESCRIPTION
the branch previously specified (v0.3.1) doesn't seem to exist.

UPDATE: `v0.3.1` was actually based on a tag that I didn't see but happened to be outdated, `v0.5.0` is the latest one, so a new commit was made to reflect that.