### PR TITLE
main: dont open output before conversion

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -77,17 +77,6 @@ func main() {
 		}
 	}
 
-	if flags.outFile == "" {
-		outFile = os.Stdout
-	} else {
-		var err error
-		outFile, err = os.Create(flags.outFile)
-		if err != nil {
-			stderr("Failed to create: %v", err)
-			os.Exit(1)
-		}
-	}
-
 	dataIn, err := ioutil.ReadAll(inFile)
 	if err != nil {
 		stderr("Failed to read: %v", err)
@@ -121,6 +110,17 @@ func main() {
 	if err != nil {
 		stderr("Failed to marshal output: %v", err)
 		os.Exit(1)
+	}
+
+	if flags.outFile == "" {
+		outFile = os.Stdout
+	} else {
+		var err error
+		outFile, err = os.Create(flags.outFile)
+		if err != nil {
+			stderr("Failed to create: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	if _, err := outFile.Write(dataOut); err != nil {


### PR DESCRIPTION
Don't open the output file/stream until after conversion is done. This prevents writing empty files when ct fails.