### PR TITLE
Support custom platforms

### DIFF
--- a/config/platform/platform.go
+++ b/config/platform/platform.go
@@ -23,6 +23,7 @@ const (
 	OpenStackMetadata     = "openstack-metadata"
 	VagrantVirtualbox     = "vagrant-virtualbox"
 	CloudStackConfigDrive = "cloudstack-configdrive"
+	Custom                = "custom"
 )
 
 var Platforms = []string{
@@ -34,6 +35,7 @@ var Platforms = []string{
 	OpenStackMetadata,
 	VagrantVirtualbox,
 	CloudStackConfigDrive,
+	Custom,
 }
 
 func IsSupportedPlatform(platform string) bool {

--- a/config/templating/templating.go
+++ b/config/templating/templating.go
@@ -76,6 +76,13 @@ var platformTemplatingMap = map[string]map[string]string{
 	platform.CloudStackConfigDrive: {
 		fieldHostname: "CLOUDSTACK_LOCAL_HOSTNAME",
 	},
+	platform.Custom: {
+		fieldHostname:  "COREOS_CUSTOM_HOSTNAME",
+		fieldV4Private: "COREOS_CUSTOM_PRIVATE_IPV4",
+		fieldV4Public:  "COREOS_CUSTOM_PUBLIC_IPV4",
+		fieldV6Private: "COREOS_CUSTOM_PRIVATE_IPV6",
+		fieldV6Public:  "COREOS_CUSTOM_PUBLIC_IPV6",
+	},
 }
 
 // HasTemplating returns whether or not any of the environment variables present


### PR DESCRIPTION
Add the ability to bring your own metadata service. Add a "custom" platform type and document how to use it by overwriting parts of the coreos-metadata service