### PR TITLE
make: fix bin/ct target dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ VERSION=$(shell git describe --dirty)
 REPO=github.com/coreos/container-linux-config-transpiler
 LD_FLAGS="-w -X $(REPO)/internal/version.Raw=$(VERSION)"
 
+GO_SOURCES=$(shell find . -name "*.go")
+
 export GOPATH=$(shell pwd)/gopath
 export CGO_ENABLED:=0
 
@@ -55,5 +57,5 @@ bin/ct-%-x86_64-unknown-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 bin/ct-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
 bin/ct-%-x86_64-pc-windows-gnu.exe: GOARGS = GOOS=windows GOARCH=amd64
 
-bin/%: | gopath
+bin/%: $(GO_SOURCES) | gopath
 	$(Q)$(GOARGS) go build -o $@ -ldflags $(LD_FLAGS) $(REPO)/internal


### PR DESCRIPTION
Prior to this, running 'make', changing go files, and running 'make'
again failed to rebuild 'bin/ct' since the file already exists and was
not a phony target (even though 'all' was).

This fixes that issue by correctly modeling the go files it depends on