### PR TITLE
config: make getCliArgs handle pointers, make etcd.EnableV2 a pointer

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1795,6 +1795,34 @@ func TestParseAndConvert(t *testing.T) {
 	}{
 		{
 			in: in{data: `
+etcd:
+    enable_v2: false
+    version: 3.3.1
+`},
+			out: out{
+				cfg: ignTypes.Config{
+					Ignition: ignTypes.Ignition{
+						Version: "2.2.0",
+					},
+					Systemd: ignTypes.Systemd{
+						Units: []ignTypes.Unit{
+							{
+								Name:   "etcd-member.service",
+								Enable: true,
+								Dropins: []ignTypes.SystemdDropin{
+									{
+										Name:     "20-clct-etcd-member.conf",
+										Contents: "[Service]\nEnvironment=\"ETCD_IMAGE_TAG=v3.3.1\"\nExecStart=\nExecStart=/usr/lib/coreos/etcd-wrapper $ETCD_OPTS \\\n  --enable-v2=false",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			in: in{data: `
 networkd:
   units:
     - name: bad.blah

--- a/config/types/common.go
+++ b/config/types/common.go
@@ -113,6 +113,9 @@ func getArgs(format, tagName string, e interface{}) []string {
 				vars = append(vars, getCliArgs(val)...)
 			} else {
 				key := et.Field(i).Tag.Get(tagName)
+				if ev.Field(i).Kind() == reflect.Ptr {
+					val = reflect.Indirect(ev.Field(i)).Interface()
+				}
 				if _, ok := val.(string); ok {
 					// to handle whitespace characters
 					val = fmt.Sprintf("%q", val)

--- a/config/types/etcd.go
+++ b/config/types/etcd.go
@@ -265,7 +265,7 @@ type Etcd3_2 struct {
 	HeartbeatInterval        int    `yaml:"heartbeat_interval"          cli:"heartbeat-interval"`
 	ElectionTimeout          int    `yaml:"election_timeout"            cli:"election-timeout"`
 	EnablePprof              bool   `yaml:"enable_pprof"                cli:"enable-pprof"`
-	EnableV2                 bool   `yaml:"enable_v2"                   cli:"enable-v2"`
+	EnableV2                 *bool  `yaml:"enable_v2"                   cli:"enable-v2"`
 	ListenPeerUrls           string `yaml:"listen_peer_urls"            cli:"listen-peer-urls"`
 	ListenClientUrls         string `yaml:"listen_client_urls"          cli:"listen-client-urls"`
 	MaxSnapshots             int    `yaml:"max_snapshots"               cli:"max-snapshots"`
@@ -316,7 +316,7 @@ type Etcd3_3 struct {
 	HeartbeatInterval               int    `yaml:"heartbeat_interval"                 cli:"heartbeat-interval"`
 	ElectionTimeout                 int    `yaml:"election_timeout"                   cli:"election-timeout"`
 	EnablePprof                     bool   `yaml:"enable_pprof"                       cli:"enable-pprof"`
-	EnableV2                        bool   `yaml:"enable_v2"                          cli:"enable-v2"`
+	EnableV2                        *bool  `yaml:"enable_v2"                          cli:"enable-v2"`
 	ListenPeerUrls                  string `yaml:"listen_peer_urls"                   cli:"listen-peer-urls"`
 	ListenClientUrls                string `yaml:"listen_client_urls"                 cli:"listen-client-urls"`
 	MaxSnapshots                    int    `yaml:"max_snapshots"                      cli:"max-snapshots"`


### PR DESCRIPTION
Also adds a test to ensure the flag for etcd is set to false.

Fixes https://github.com/coreos/bugs/issues/2428

We should definitely do a full audit of options, I wouldn't be surprised if there are other fields with this issue. Until we do though, this will at least fix the reported issue.