### PR TITLE
readme: add note about fcct

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The Config Transpiler ("ct" for short) is the utility responsible for transforming a human-friendly Container Linux Config into a JSON file. This resulting file can be provided to a Container Linux machine when it first boots to provision the machine.
 
+**NOTE: This tool is for Container Linux, not Fedora CoreOS. See [FCCT](https://github.com/coreos/fcct) for the Fedora CoreOS equivalent.**
+
 ## Documentation
 
 If you're looking to begin writing configs for your Container Linux machines, check out the [getting started][get-started] documentation.


### PR DESCRIPTION
Add a note that this tool is for Container Linux and direct Fedora
CoreOS users to FCCT.